### PR TITLE
fix: replace removed addUserTSConfig() with defaultUserTSconfig global

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -30,15 +30,19 @@ call_user_func(static function (): void {
     $newsletterPageDokType = $configuration->getNewsletterPageDokType();
 
     // We need to add the following user TypoScript config to all users, so that the new
-    // page type is displayed in the wizard
+    // page type is displayed in the wizard.
+    //
+    // ExtensionManagementUtility::addUserTSConfig() was removed in TYPO3 v13, so we append
+    // to $GLOBALS['TYPO3_CONF_VARS']['BE']['defaultUserTSconfig'] directly. This is the
+    // supported way to register dynamic user TSconfig in TYPO3 v13+.
     //
     // In TYPO3 v14, the dynamic configuration must be rebuilt. Currently, you cannot access
     // configured constants.typoscript in the user.tsconfig.
     //
     // See https://forge.typo3.org/issues/106069
-    ExtensionManagementUtility::addUserTSConfig(
-        'options.pageTree.doktypesToShowInNewPageDragArea := addToList(' . $newsletterPageDokType . ')',
-    );
+    $GLOBALS['TYPO3_CONF_VARS']['BE']['defaultUserTSconfig'] = ($GLOBALS['TYPO3_CONF_VARS']['BE']['defaultUserTSconfig'] ?? '')
+        . LF
+        . 'options.pageTree.doktypesToShowInNewPageDragArea := addToList(' . $newsletterPageDokType . ')';
 
     // Service
     ExtensionManagementUtility::addService(


### PR DESCRIPTION
## Summary

Fixes all four failing CI jobs on main (run [24021730743](https://github.com/netresearch/t3x-universal-messenger/actions/runs/24021730743)): ci/Code Style, ci/Rector, license-check/PHP License Audit and security/Composer Audit.

## Root cause

`ExtensionManagementUtility::addUserTSConfig()` was removed in TYPO3 v13 (the extension already requires `typo3/cms-core ^13.4 || ^14.0`). During `composer install`, TYPO3's post-install `asset:publish` command bootstraps every extension and threw:

```
Uncaught TYPO3 Exception
Call to undefined method TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addUserTSConfig()
thrown in ext_localconf.php line 39
```

Because this happened during `composer install`, every CI job aborted with `Failed to run command asset:publish` before its real check step (rector / cs-fix / audit / license-check) ever ran. One root cause, four red jobs.

## Fix

Replace the removed API with a direct append to `$GLOBALS['TYPO3_CONF_VARS']['BE']['defaultUserTSconfig']` - the supported way to register dynamic user TSconfig in TYPO3 v13+ which keeps the runtime-computed `$newsletterPageDokType` usable.

## Test plan

- [x] `composer install` succeeds (asset:publish runs cleanly)
- [x] `composer rector --dry-run` - OK
- [x] `php-cs-fixer fix --dry-run` - 0 files to fix
- [x] `composer audit` - no vulnerabilities
- [ ] CI green on PR