### PR TITLE
fix(phpstan): resolve 1 issue uncovered after v13 composer-install fix

### DIFF
--- a/Build/phpstan-baseline.neon
+++ b/Build/phpstan-baseline.neon
@@ -41,12 +41,3 @@ parameters:
 			identifier: missingType.iterableValue
 			count: 1
 			path: ../Classes/DataProcessing/ControlStructureProcessor.php
-
-		-
-			message: '''
-				#^Call to deprecated method addUserTSConfig\(\) of class TYPO3\\CMS\\Core\\Utility\\ExtensionManagementUtility\:
-				since TYPO3 v13\.0, will be removed in TYPO3 v14\.0\.$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 1
-			path: ../ext_localconf.php


### PR DESCRIPTION
## Summary

PR #38 removed the TYPO3 v13-incompatible `ExtensionManagementUtility::addUserTSConfig()` call in `ext_localconf.php` to unblock `composer install` on the CI matrix. With composer-install fixed, PHPStan actually started running on all three PHP versions (8.2/8.3/8.4) and failed because `Build/phpstan-baseline.neon` still contained an ignore pattern for the now-removed deprecation call.

PHPStan treats unmatched `ignoreErrors` entries as hard errors, so the job failed identically across the whole matrix.

## Failing error

Reported by PHPStan (exact CI message):

```
Ignored error pattern #^Call to deprecated method addUserTSConfig\(\) of class TYPO3\\CMS\\Core\\Utility\\ExtensionManagementUtility\:
since TYPO3 v13\.0, will be removed in TYPO3 v14\.0\.$# (staticMethod.deprecated)
in path ext_localconf.php was not matched in reported errors.
```

## Fix

- `Build/phpstan-baseline.neon`: drop the stale `staticMethod.deprecated` ignore entry for `../ext_localconf.php` (the underlying call was already removed in PR #38).

No source code changes, no level changes, no scope expansion.

## Verification

- `composer install` with `typo3/cms-core:^13.4` (matching CI matrix)
- `vendor/bin/phpstan analyse --configuration Build/phpstan.neon --memory-limit=-1` -> `[OK] No errors`

## Test plan

- [ ] CI `PHPStan (8.2, ^13.4)` green
- [ ] CI `PHPStan (8.3, ^13.4)` green
- [ ] CI `PHPStan (8.4, ^13.4)` green