### PR TITLE
fix: use Record API in preview listener for TYPO3 v14 (#43)

### DIFF
--- a/Build/phpstan-baseline.neon
+++ b/Build/phpstan-baseline.neon
@@ -7,24 +7,6 @@ parameters:
 			path: ../Classes/Backend/EventListener/ModifyPageLayoutContentEventListener.php
 
 		-
-			message: '#^Cannot access offset ''CType'' on TYPO3\\CMS\\Core\\Domain\\RecordInterface\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: ../Classes/Backend/EventListener/PageContentPreviewRenderingEventListener.php
-
-		-
-			message: '#^Cannot access offset ''bodytext'' on TYPO3\\CMS\\Core\\Domain\\RecordInterface\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: ../Classes/Backend/EventListener/PageContentPreviewRenderingEventListener.php
-
-		-
-			message: '#^Cannot access offset ''pi_flexform'' on TYPO3\\CMS\\Core\\Domain\\RecordInterface\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: ../Classes/Backend/EventListener/PageContentPreviewRenderingEventListener.php
-
-		-
 			message: '#^Method Netresearch\\UniversalMessenger\\Command\\ImportCommand\:\:getStoragePageId\(\) should return int\<0, max\> but returns int\.$#'
 			identifier: return.type
 			count: 1

--- a/Classes/Backend/EventListener/PageContentPreviewRenderingEventListener.php
+++ b/Classes/Backend/EventListener/PageContentPreviewRenderingEventListener.php
@@ -58,7 +58,7 @@ final readonly class PageContentPreviewRenderingEventListener
         }
 
         $flexformData = $this->flexFormService
-            ->convertFlexFormContentToArray($record->get('pi_flexform') ?? '');
+            ->convertFlexFormContentToArray($record->getRawRecord()?->get('pi_flexform') ?? '');
 
         $replacementBodyText = $flexformData['settings']['replacementBodyText'] ?? '';
 

--- a/Classes/Backend/EventListener/PageContentPreviewRenderingEventListener.php
+++ b/Classes/Backend/EventListener/PageContentPreviewRenderingEventListener.php
@@ -51,12 +51,14 @@ final readonly class PageContentPreviewRenderingEventListener
             return;
         }
 
-        if ($event->getRecord()['CType'] !== 'control_structure') {
+        $record = $event->getRecord();
+
+        if ($record->getRecordType() !== 'control_structure') {
             return;
         }
 
         $flexformData = $this->flexFormService
-            ->convertFlexFormContentToArray($event->getRecord()['pi_flexform'] ?? '');
+            ->convertFlexFormContentToArray($record->get('pi_flexform') ?? '');
 
         $replacementBodyText = $flexformData['settings']['replacementBodyText'] ?? '';
 
@@ -69,7 +71,7 @@ final readonly class PageContentPreviewRenderingEventListener
             <strong>{$this->translate('content_element.control_structure.bodytext')}</strong>
         </div>
         <div>
-            {$event->getRecord()['bodytext']}
+            {$record->get('bodytext')}
         </div>
     </div>
     <div>


### PR DESCRIPTION
## Summary

Fixes the fatal error when rendering a `control_structure` content-element preview in the page module on TYPO3 v14:

```
Cannot use object of type TYPO3\CMS\Core\Domain\Record as array
```

On v14, `PageContentPreviewRenderingEvent::getRecord()` returns a `TYPO3\CMS\Core\Domain\Record` object, so the listener's old array access (`$record['CType']`, `$record['pi_flexform']`, `$record['bodytext']`) was invalid.

Closes #43.

## Changes

`Classes/Backend/EventListener/PageContentPreviewRenderingEventListener.php` — switch to the v14 Record API:

- `$record->getRecordType()` for the content-type check (tt_content's sub-schema divisor is `CType`, so this returns `control_structure`)
- `$record->get('bodytext')` for the body text (TCA `text` field → raw value)
- `$record->getRawRecord()?->get('pi_flexform') ?? ''` for the FlexForm content

The `pi_flexform` handling reads the **raw** record deliberately: on a resolved `Record`, `get('pi_flexform')` returns a `FlexFormFieldValues` object (the field is TCA type `flex`), not the raw XML string that `convertFlexFormContentToArray(string)` expects — passing the object would throw a `TypeError`. `getRawRecord()` yields the unmodified DB value; `?->` guards the nullable `getRawRecord(): ?RawRecord`.

`Build/phpstan-baseline.neon` — removed the three now-fixed `RecordInterface` offset-access entries.

## Quality

- `composer ci:test` green (phplint, PHPStan level 8, Rector, php-cs-fixer)
- Multi-reviewer audit loop (correctness, TYPO3 v14 migration, maintainability, project standards, general review) to two consecutive zero-finding rounds; the loop caught and fixed the `pi_flexform` `FlexFormFieldValues`-vs-string TypeError before opening this PR
