### PR TITLE
fix: register control_structure FlexForm via columnsOverrides for v14 (#46)

### DIFF
--- a/Build/phpstan-baseline.neon
+++ b/Build/phpstan-baseline.neon
@@ -59,12 +59,3 @@ parameters:
 			identifier: missingType.iterableValue
 			count: 1
 			path: ../Classes/DataProcessing/ControlStructureProcessor.php
-
-		-
-			message: '''
-				#^Call to deprecated method addPiFlexFormValue\(\) of class TYPO3\\CMS\\Core\\Utility\\ExtensionManagementUtility\:
-				Will be removed in TYPO3 v15$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 1
-			path: ../Configuration/TCA/Overrides/tt_content.php

--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -79,16 +79,16 @@ call_user_func(static function (): void {
                                 'enableRichtext' => true,
                             ],
                         ],
+                        'pi_flexform' => [
+                            'config' => [
+                                // v14: the flex pointer-field mechanism (addPiFlexFormValue) was
+                                // removed (#107047); register the data structure directly here.
+                                'ds' => 'FILE:EXT:universal_messenger/Configuration/FlexForms/ControlStructure.xml',
+                            ],
+                        ],
                     ],
                 ],
             ],
         ],
-    );
-
-    // Add flexForms for content element configuration
-    ExtensionManagementUtility::addPiFlexFormValue(
-        '*',
-        'FILE:EXT:universal_messenger/Configuration/FlexForms/ControlStructure.xml',
-        'control_structure',
     );
 });


### PR DESCRIPTION
## Summary

`ExtensionManagementUtility::addPiFlexFormValue('*', …, 'control_structure')` is deprecated in TYPO3 v14 (#107047) and relies on the flex **pointer-field** mechanism, which was removed — so the `control_structure` content element's FlexForm could stop showing.

Closes #46.

## Change

`Configuration/TCA/Overrides/tt_content.php` — register the data structure declaratively on the content type instead of via the deprecated API:

```php
'types' => [
    'control_structure' => [
        'columnsOverrides' => [
            'pi_flexform' => [
                'config' => [
                    'ds' => 'FILE:EXT:universal_messenger/Configuration/FlexForms/ControlStructure.xml',
                ],
            ],
        ],
    ],
],
```

This is byte-equivalent to what `addPiFlexFormValue()` did internally — the v14 core implementation of that method literally sets `types[$CType]['columnsOverrides']['pi_flexform']['config']['ds']`. `columnsOverrides` scopes the DS to the `control_structure` type only (the field must be in that type's `showitem`, which it is); a plain `FILE:` string is the v14 `ds` format now that the pointer field is gone.

`Build/phpstan-baseline.neon` — removed the now-fixed `addPiFlexFormValue` deprecation entry.

## Quality

- `composer ci:test` green (phplint, PHPStan level 8, Rector, php-cs-fixer)
- Multi-reviewer audit loop (correctness, TYPO3 v14 migration, maintainability, project standards, general review) to two consecutive zero-finding rounds; the TYPO3 reviewer confirmed the new registration resolves through `FlexFormTools` identically to the old call
