### PR TITLE
fix: absolute newsletter preview URL for relative site bases (v14) (#42)

### DIFF
--- a/Classes/Controller/UniversalMessengerController.php
+++ b/Classes/Controller/UniversalMessengerController.php
@@ -25,6 +25,7 @@ use Netresearch\UniversalMessenger\Repository\EventFileRepository;
 use Netresearch\UniversalMessenger\Repository\NewsletterRepository;
 use Netresearch\UniversalMessenger\Service\NewsletterRenderService;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\UriInterface;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 
@@ -468,6 +469,22 @@ class UniversalMessengerController extends AbstractBaseController implements Log
             ])
             ->withLanguage($this->currentSelectedLanguage)
             ->buildUri();
+
+        if (!$previewUri instanceof UriInterface) {
+            return '';
+        }
+
+        // A site configured with a relative base (base: /, the TYPO3 v14 default) produces
+        // a host-less preview URI. Turn it into an absolute URL using the current backend
+        // request, so it passes URL validation and can be fetched when rendering the
+        // newsletter page for sending.
+        if ($previewUri->getHost() === '') {
+            $requestUri = $this->request->getUri();
+            $previewUri = $previewUri
+                ->withScheme($requestUri->getScheme())
+                ->withHost($requestUri->getHost())
+                ->withPort($requestUri->getPort());
+        }
 
         return (string) $previewUri;
     }


### PR DESCRIPTION
## Summary

The backend module aborted with **"The requested page is missing a valid site configuration"** (`error.noSiteConfiguration`) whenever the site used a **relative** base (`base: /`, the TYPO3 v14 default).

`PreviewUriBuilder::buildUri()` then produces a host-less URL, which `isUrlValid()` (`filter_var(FILTER_VALIDATE_URL)`) rejects — even though the site config is fine. The same host-less URL also could not be fetched over HTTP on the send path (`NewsletterRenderService::renderNewsletterPage()`).

Closes #42.

## Change

`Classes/Controller/UniversalMessengerController.php` — `getNewsletterUrl()`:

- return `''` when `buildUri()` yields `null` (genuine no-site → preserves the `error.noSiteConfiguration` path)
- when the built preview URI has **no host** (relative base), make it absolute using the current backend request's scheme/host/port:

```php
if ($previewUri->getHost() === '') {
    $requestUri = $this->request->getUri();
    $previewUri = $previewUri
        ->withScheme($requestUri->getScheme())
        ->withHost($requestUri->getHost())
        ->withPort($requestUri->getPort());
}
```

This fixes both call sites (iframe preview and the send-time HTTP fetch) with one change. Sites with an absolute `base:` keep a non-empty host and are untouched.

## Notes

- Deriving the host from the current request is the conventional technique for a relative base (the host is, by definition, whatever the request arrives on). A split backend/frontend-domain deployment should configure an absolute `base:`; then the host-rewrite branch never runs.

## Quality

- `composer ci:test` green (phplint, PHPStan level 8, Rector, php-cs-fixer)
- Multi-reviewer audit loop (correctness, TYPO3 v14 migration, maintainability, project standards, general review) to two consecutive zero-finding rounds; `$this->request->getUri()` availability, `withPort(null)` validity, and the null/no-site path all verified against the v14 core
