### PR TITLE
fix: remove invalid eval=int from RTE FlexForm field (v14) (#47)

### DIFF
--- a/Configuration/FlexForms/ControlStructure.xml
+++ b/Configuration/FlexForms/ControlStructure.xml
@@ -15,7 +15,6 @@
                             <type>text</type>
                             <cols>80</cols>
                             <rows>15</rows>
-                            <eval>int,required</eval>
                             <softref>typolink_tag,email[subst],url</softref>
                             <enableRichtext>1</enableRichtext>
                         </config>


### PR DESCRIPTION
## Summary

The FlexForm field `settings.replacementBodyText` is a **richtext** field (`<type>text</type>`, `<enableRichtext>1</enableRichtext>`) but declared `<eval>int,required</eval>`:

- `eval=int` on RTE content casts the stored HTML to an integer on save → **data loss** (HTML becomes `0`).
- In TYPO3 v14, `required` is its own TCA property, not an `eval` keyword.
- The field is read **optionally** everywhere (`?? ''`), so it is not actually mandatory.

Closes #47.

## Change

`Configuration/FlexForms/ControlStructure.xml` — drop the `<eval>int,required</eval>` line entirely. The field stays a plain optional richtext field (`softref` and `enableRichtext` unchanged).

`required` is intentionally *not* re-added as `<required>1</required>`: both consumers default the value to `''`
(`ControlStructureProcessor` → `f:format.raw`, and `PageContentPreviewRenderingEventListener`), and no code path depends on it being non-empty.

## Quality

- `composer ci:test` green; FlexForm XML well-formed
- Multi-reviewer audit loop (correctness, TYPO3 v14 migration, maintainability, project standards, general review) to two consecutive zero-finding rounds; all three read sites verified to tolerate an empty/absent value with no int/non-empty assumption
