### PR TITLE
feat: TYPO3 v14 Site Set for site-set-based sites (#41)

### DIFF
--- a/Configuration/Sets/UniversalMessenger/config.yaml
+++ b/Configuration/Sets/UniversalMessenger/config.yaml
@@ -1,0 +1,2 @@
+name: netresearch/universal-messenger
+label: 'Universal Messenger'

--- a/Configuration/Sets/UniversalMessenger/setup.typoscript
+++ b/Configuration/Sets/UniversalMessenger/setup.typoscript
@@ -1,0 +1,9 @@
+# TYPO3 v14 Site Set.
+#
+# Site-Set-based sites have no sys_template record, so the classic static
+# templates registered via ExtensionManagementUtility::addStaticFile() are never
+# included. Add "netresearch/universal-messenger" to the site's dependencies to
+# load the newsletter preview PAGE type (typeNum 1715682913), the plugin and the
+# content-element TypoScript. The classic static templates remain in parallel for
+# legacy (non-Site-Set) setups.
+@import 'EXT:universal_messenger/Configuration/TypoScript/Default/setup.typoscript'

--- a/Configuration/Sets/UniversalMessenger/setup.typoscript
+++ b/Configuration/Sets/UniversalMessenger/setup.typoscript
@@ -1,9 +1,13 @@
 # TYPO3 v14 Site Set.
 #
-# Site-Set-based sites have no sys_template record, so the classic static
-# templates registered via ExtensionManagementUtility::addStaticFile() are never
-# included. Add "netresearch/universal-messenger" to the site's dependencies to
-# load the newsletter preview PAGE type (typeNum 1715682913), the plugin and the
-# content-element TypoScript. The classic static templates remain in parallel for
-# legacy (non-Site-Set) setups.
+# Provides the extension's default TypoScript - the newsletter preview PAGE type
+# (typeNum 1715682913), the plugin and the content-element configuration - to
+# Site-Set-based v14 sites. Add "netresearch/universal-messenger" to the site's
+# dependencies to load it.
+#
+# Classic (sys_template-based) sites receive the same TypoScript via
+# ExtensionManagementUtility::addTypoScript() in ext_localconf.php; that call passes
+# includeInSiteSets = false, so this Set is the single, opt-in source for site-set
+# sites and the TypoScript is not loaded twice. The addStaticFile() templates (Fluid
+# content elements, example newsletter) remain classic-only.
 @import 'EXT:universal_messenger/Configuration/TypoScript/Default/setup.typoscript'

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -19,11 +19,17 @@ use TYPO3\CMS\Extbase\Utility\ExtensionUtility;
 defined('TYPO3') || exit('Access denied.');
 
 call_user_func(static function (): void {
-    // Add TypoScript automatically (to use it in backend modules)
+    // Register the extension's default TypoScript for classic (sys_template-based) sites
+    // via the global default TypoScript setup. Site-Set-based v14 sites load the same
+    // TypoScript through the "netresearch/universal-messenger" Site Set instead (see
+    // Configuration/Sets/UniversalMessenger), so includeInSiteSets is disabled here to
+    // avoid force-injecting it into every site-set site and loading it twice.
     ExtensionManagementUtility::addTypoScript(
         'universal_messenger',
         'setup',
         '@import "EXT:universal_messenger/Configuration/TypoScript/Default/setup.typoscript"',
+        0,
+        false,
     );
 
     $configuration         = GeneralUtility::makeInstance(Configuration::class);


### PR DESCRIPTION
## Summary

Makes the extension's TypoScript loadable in **TYPO3 v14 Site-Set-based sites** through an explicit, opt-in **Site Set**, instead of force-injecting it into every site-set site.

Closes #41.

## Background

Issue #41 reported that the newsletter preview PAGE type (`typeNum 1715682913`) is undefined on Site-Set-based sites → *"No page configured for type=1715682913"*.

The extension registers its default TypoScript via `ExtensionManagementUtility::addTypoScript()` in `ext_localconf.php`. In v14 that call defaults to `includeInSiteSets = true`, which appends the TypoScript to the `defaultTypoScript_setup.['siteSets']` global — force-injected into **every** site-set site (`SysTemplateTreeBuilder::createSiteTemplateInclude()`), regardless of whether the site wants the newsletter feature. That is both an over-injection and not the v14-idiomatic opt-in model.

## Change

- **New Site Set** `Configuration/Sets/UniversalMessenger/` (`config.yaml` + `setup.typoscript`) that imports the extension's existing `Default/setup.typoscript` (newsletter preview PAGE, plugin, content-element config). A v14 site loads it by adding `netresearch/universal-messenger` to its site `dependencies`.
- **`ext_localconf.php`**: `addTypoScript(..., 0, false)` → `includeInSiteSets = false`. The Site Set becomes the single, opt-in source for site-set sites (no double-load, no force-inject into unrelated sites). Classic `sys_template`-based sites keep receiving the TypoScript via the unscoped `defaultTypoScript_setup` bucket (unaffected by the flag) plus the existing `addStaticFile()` templates.

The `addStaticFile()` demo/fluid templates (Fluid content elements, example newsletter) remain classic-only, as before.

## Site configuration

Site-Set-based v14 sites must now add the set to their site config to get the newsletter TypoScript:

```yaml
dependencies:
  - netresearch/universal-messenger
```

## Quality

- `composer ci:test` green (phplint, PHPStan level 8, Rector, php-cs-fixer)
- Multi-reviewer audit loop (correctness, TYPO3 v14 migration, maintainability, project standards, general review) to two consecutive zero-finding rounds. The loop traced the loading through `SysTemplateTreeBuilder` and drove the `includeInSiteSets=false` design, confirmed the set is self-contained (no `dependencies:` needed) and correctly excludes the FSC-dependent `FluidContentElements` and the `ExampleNewsletter` demo.
- Recommended follow-up: verify on a live site-set site that adding the dependency resolves `typeNum 1715682913` (functional test not covered by `ci:test`).
