### PR TITLE
fix: replace deprecated getExistingPageTranslations with LocalizationRepository (#48)

### DIFF
--- a/Build/phpstan-baseline.neon
+++ b/Build/phpstan-baseline.neon
@@ -13,15 +13,6 @@ parameters:
 			path: ../Classes/Command/ImportCommand.php
 
 		-
-			message: '''
-				#^Call to deprecated method getExistingPageTranslations\(\) of class TYPO3\\CMS\\Backend\\Utility\\BackendUtility\:
-				will be removed in TYPO3 v15\.0 \- use LocalizationRepository\-\>getPageTranslations\(\) instead\.$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 1
-			path: ../Classes/Controller/AbstractBaseController.php
-
-		-
 			message: '#^Cannot access offset ''id'' on array\|object\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 1

--- a/Classes/Controller/AbstractBaseController.php
+++ b/Classes/Controller/AbstractBaseController.php
@@ -17,6 +17,7 @@ use Netresearch\UniversalMessenger\Configuration;
 use Netresearch\UniversalMessenger\Domain\Repository\NewsletterChannelRepository;
 use Netresearch\UniversalMessenger\Service\NewsletterRenderService;
 use Psr\Http\Message\ResponseInterface;
+use TYPO3\CMS\Backend\Domain\Repository\Localization\LocalizationRepository;
 use TYPO3\CMS\Backend\Module\ModuleData;
 use TYPO3\CMS\Backend\Routing\Exception\RouteNotFoundException;
 use TYPO3\CMS\Backend\Routing\UriBuilder;
@@ -84,6 +85,11 @@ abstract class AbstractBaseController extends ActionController
     protected readonly ComponentFactory $componentFactory;
 
     /**
+     * @var LocalizationRepository
+     */
+    protected readonly LocalizationRepository $localizationRepository;
+
+    /**
      * The selected page ID.
      *
      * @var int
@@ -127,6 +133,7 @@ abstract class AbstractBaseController extends ActionController
      * @param NewsletterChannelRepository $newsletterChannelRepository
      * @param NewsletterRenderService     $newsletterRenderService
      * @param ComponentFactory            $componentFactory
+     * @param LocalizationRepository      $localizationRepository
      */
     public function __construct(
         ModuleTemplateFactory $moduleTemplateFactory,
@@ -134,12 +141,14 @@ abstract class AbstractBaseController extends ActionController
         NewsletterChannelRepository $newsletterChannelRepository,
         NewsletterRenderService $newsletterRenderService,
         ComponentFactory $componentFactory,
+        LocalizationRepository $localizationRepository,
     ) {
         $this->moduleTemplateFactory       = $moduleTemplateFactory;
         $this->configuration               = $configuration;
         $this->newsletterChannelRepository = $newsletterChannelRepository;
         $this->newsletterRenderService     = $newsletterRenderService;
         $this->componentFactory            = $componentFactory;
+        $this->localizationRepository      = $localizationRepository;
     }
 
     /**
@@ -246,11 +255,10 @@ abstract class AbstractBaseController extends ActionController
         if ($this->pageId > 0) {
             // Compile language data for pid != 0 only. The language drop-down is not shown on pid 0
             // since pid 0 can't be localized.
-            $pageTranslations = BackendUtility::getExistingPageTranslations($this->pageId);
+            // getPageTranslations() returns the translation records indexed by language id.
+            $pageTranslations = $this->localizationRepository->getPageTranslations($this->pageId);
 
-            foreach ($pageTranslations as $pageTranslation) {
-                $languageId = $pageTranslation[$GLOBALS['TCA']['pages']['ctrl']['languageField']];
-
+            foreach (array_keys($pageTranslations) as $languageId) {
                 if (isset($this->availableLanguages[$languageId])) {
                     $this->languages[$languageId] = $this->availableLanguages[$languageId]->getTitle();
                 }

--- a/Classes/Controller/AbstractBaseController.php
+++ b/Classes/Controller/AbstractBaseController.php
@@ -256,7 +256,13 @@ abstract class AbstractBaseController extends ActionController
             // Compile language data for pid != 0 only. The language drop-down is not shown on pid 0
             // since pid 0 can't be localized.
             // getPageTranslations() returns the translation records indexed by language id.
-            $pageTranslations = $this->localizationRepository->getPageTranslations($this->pageId);
+            // Pass the current backend user workspace to keep the workspace-aware behaviour
+            // of the removed BackendUtility::getExistingPageTranslations().
+            $pageTranslations = $this->localizationRepository->getPageTranslations(
+                $this->pageId,
+                [],
+                $this->getBackendUserAuthentication()->workspace,
+            );
 
             foreach (array_keys($pageTranslations) as $languageId) {
                 if (isset($this->availableLanguages[$languageId])) {

--- a/Classes/Controller/UniversalMessengerController.php
+++ b/Classes/Controller/UniversalMessengerController.php
@@ -31,6 +31,7 @@ use Psr\Log\LoggerAwareTrait;
 
 use function sprintf;
 
+use TYPO3\CMS\Backend\Domain\Repository\Localization\LocalizationRepository;
 use TYPO3\CMS\Backend\Routing\Exception\RouteNotFoundException;
 use TYPO3\CMS\Backend\Routing\PreviewUriBuilder;
 use TYPO3\CMS\Backend\Template\Components\ButtonBar;
@@ -90,6 +91,7 @@ class UniversalMessengerController extends AbstractBaseController implements Log
      * @param NewsletterChannelRepository $newsletterChannelRepository
      * @param NewsletterRenderService     $newsletterRenderService
      * @param ComponentFactory            $componentFactory
+     * @param LocalizationRepository      $localizationRepository
      * @param SiteFinder                  $siteFinder
      * @param EventFileRepository         $eventFileRepository
      * @param NewsletterRepository        $newsletterRepository
@@ -100,6 +102,7 @@ class UniversalMessengerController extends AbstractBaseController implements Log
         NewsletterChannelRepository $newsletterChannelRepository,
         NewsletterRenderService $newsletterRenderService,
         ComponentFactory $componentFactory,
+        LocalizationRepository $localizationRepository,
         SiteFinder $siteFinder,
         EventFileRepository $eventFileRepository,
         NewsletterRepository $newsletterRepository,
@@ -110,6 +113,7 @@ class UniversalMessengerController extends AbstractBaseController implements Log
             $newsletterChannelRepository,
             $newsletterRenderService,
             $componentFactory,
+            $localizationRepository,
         );
 
         $this->siteFinder           = $siteFinder;


### PR DESCRIPTION
## Summary

`BackendUtility::getExistingPageTranslations()` is deprecated in TYPO3 v14 (removal in v15). Replace it with the injectable `LocalizationRepository::getPageTranslations()`.

Closes #48.

## Change

`Classes/Controller/AbstractBaseController.php` (`makeLanguageSwitchButton`):

- Inject `TYPO3\CMS\Backend\Domain\Repository\Localization\LocalizationRepository` via constructor DI (autowirable, `#[Autoconfigure(public: true)]`), threaded through the `UniversalMessengerController` constructor — mirroring the existing `ComponentFactory` pattern.
- `getPageTranslations()` returns the translation records (`RawRecord`) **indexed by language id**, so the available-language list is built from the array keys directly — dropping the `$GLOBALS['TCA']['pages']['ctrl']['languageField']` lookup.
- Pass the current backend user workspace as the 3rd argument so the workspace-aware behaviour of the removed method is preserved (surfaced by the review loop).

`Build/phpstan-baseline.neon`: removed the now-fixed `getExistingPageTranslations` deprecation entry.

## Quality

- `composer ci:test` green (phplint, PHPStan level 8, Rector, php-cs-fixer)
- Multi-reviewer audit loop (correctness, TYPO3 v14 migration, maintainability, project standards, general review) to two consecutive zero-finding rounds. Three reviewers independently flagged the workspace-context difference (live vs the editor's workspace); it was fixed by passing `getBackendUserAuthentication()->workspace`, and the language-id set equivalence + DI wiring were verified against the v14 core.
