### PR TITLE
fix: replace deprecated getRecordLocalization with LocalizationRepository (#57)

### DIFF
--- a/Build/phpstan-baseline.neon
+++ b/Build/phpstan-baseline.neon
@@ -19,15 +19,6 @@ parameters:
 			path: ../Classes/Controller/AbstractBaseController.php
 
 		-
-			message: '''
-				#^Call to deprecated method getRecordLocalization\(\) of class TYPO3\\CMS\\Backend\\Utility\\BackendUtility\:
-				will be removed in TYPO3 v15\.0 \- use LocalizationRepository\-\>getRecordTranslation\(\) instead\.$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 1
-			path: ../Classes/Controller/UniversalMessengerController.php
-
-		-
 			message: '#^Method Netresearch\\UniversalMessenger\\DataProcessing\\ControlStructureProcessor\:\:process\(\) has parameter \$contentObjectConfiguration with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1

--- a/Classes/Controller/UniversalMessengerController.php
+++ b/Classes/Controller/UniversalMessengerController.php
@@ -39,6 +39,7 @@ use TYPO3\CMS\Backend\Template\Components\Buttons\ButtonInterface;
 use TYPO3\CMS\Backend\Template\Components\ComponentFactory;
 use TYPO3\CMS\Backend\Template\ModuleTemplateFactory;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Core\Domain\RawRecord;
 use TYPO3\CMS\Core\Exception\SiteNotFoundException;
 use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
 use TYPO3\CMS\Core\Site\SiteFinder;
@@ -227,14 +228,15 @@ class UniversalMessengerController extends AbstractBaseController implements Log
      */
     private function getPageTitle(?array $pageRecord): string
     {
-        $localizedRecord = BackendUtility::getRecordLocalization(
+        $localizedRecord = $this->localizationRepository->getRecordTranslation(
             'pages',
             $this->pageId,
             $this->currentSelectedLanguage,
+            $this->getBackendUserAuthentication()->workspace,
         );
 
-        if ($localizedRecord !== []) {
-            return $localizedRecord[0]['title'] ?? '';
+        if ($localizedRecord instanceof RawRecord) {
+            return (string) ($localizedRecord->get('title') ?? '');
         }
 
         return (string) ($pageRecord['title'] ?? '');


### PR DESCRIPTION
## Summary

`BackendUtility::getRecordLocalization()` is deprecated in TYPO3 v14 (removal in v15) and is **not** covered by typo3-rector. Replace it with the injectable `LocalizationRepository::getRecordTranslation()`.

Closes #57.

## Change

`Classes/Controller/UniversalMessengerController.php` (`getPageTitle`):

- Use the already-injected `$this->localizationRepository` (added in #48) — no new injection needed.
- `getRecordTranslation()` returns a single `?RawRecord` instead of an array of rows, so the code now checks `instanceof RawRecord` and reads the title via `RawRecord::get('title')` (was `$localizedRecord[0]['title']`).
- Pass the current backend user workspace (4th argument) to preserve the workspace-aware behaviour of the old method.

`Build/phpstan-baseline.neon`: removed the now-fixed `getRecordLocalization` deprecation entry.

## Quality

- `composer ci:test` green (phplint, PHPStan level 8, Rector, php-cs-fixer)
- Multi-reviewer audit loop (correctness, TYPO3 v14 migration, maintainability, project standards, general review) to two consecutive zero-finding rounds. Reviewers confirmed the query semantics are equivalent (same l10n_source-over-l10n_parent preference, same single-row selection, workspace parity) and that the new method is in fact slightly stricter (adds workspace overlay + DELETE_PLACEHOLDER filtering).
