### PR TITLE
fix: do not run the request chain twice in InlineCssMiddleware (#49)

### DIFF
--- a/Classes/Middleware/InlineCssMiddleware.php
+++ b/Classes/Middleware/InlineCssMiddleware.php
@@ -70,7 +70,8 @@ class InlineCssMiddleware implements MiddlewareInterface
             return $response;
         }
 
-        $stream = $requestHandler->handle($serverRequest)->getBody();
+        // Extract the content
+        $stream = $response->getBody();
         $stream->rewind();
 
         $content   = $stream->getContents();


### PR DESCRIPTION
## Summary

`InlineCssMiddleware::process()` called `$requestHandler->handle($serverRequest)` **twice** — once to obtain `$response`, then again only to read the body stream. This ran the entire frontend request chain a second time (doubled rendering and side effects), and the CSS was inlined onto the body of the *second* response while `withBody()` was applied to the *first*.

Closes #49.

## Change

`Classes/Middleware/InlineCssMiddleware.php` — read the body from the already-obtained `$response`:

```php
$stream = $response->getBody();
```

This matches the sibling `DecodeCurlyBracesMiddleware`, which already used the correct single-`handle()` pattern.

## Quality

- `composer ci:test` green (phplint, PHPStan level 8, Rector, php-cs-fixer)
- Multi-reviewer audit loop (correctness, TYPO3/PSR-15, maintainability, project standards, general review) to two consecutive zero-finding rounds. Reviewers confirmed single-`handle()` is correct PSR-15 behaviour, the response is re-wrapped immutably, and `rewind()` on the seekable core FE stream keeps `getContents()` correct.
