### PR TITLE
refactor: use FlexFormTools instead of the deprecated FlexFormService alias (#52)

### DIFF
--- a/Classes/Backend/EventListener/PageContentPreviewRenderingEventListener.php
+++ b/Classes/Backend/EventListener/PageContentPreviewRenderingEventListener.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 namespace Netresearch\UniversalMessenger\Backend\EventListener;
 
 use TYPO3\CMS\Backend\View\Event\PageContentPreviewRenderingEvent;
-use TYPO3\CMS\Core\Service\FlexFormService;
+use TYPO3\CMS\Core\Configuration\FlexForm\FlexFormTools;
 use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 
 /**
@@ -26,18 +26,18 @@ use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 final readonly class PageContentPreviewRenderingEventListener
 {
     /**
-     * @var FlexFormService
+     * @var FlexFormTools
      */
-    private FlexFormService $flexFormService;
+    private FlexFormTools $flexFormTools;
 
     /**
      * Constructor.
      *
-     * @param FlexFormService $flexFormService
+     * @param FlexFormTools $flexFormTools
      */
-    public function __construct(FlexFormService $flexFormService)
+    public function __construct(FlexFormTools $flexFormTools)
     {
-        $this->flexFormService = $flexFormService;
+        $this->flexFormTools = $flexFormTools;
     }
 
     /**
@@ -57,7 +57,7 @@ final readonly class PageContentPreviewRenderingEventListener
             return;
         }
 
-        $flexformData = $this->flexFormService
+        $flexformData = $this->flexFormTools
             ->convertFlexFormContentToArray($record->getRawRecord()?->get('pi_flexform') ?? '');
 
         $replacementBodyText = $flexformData['settings']['replacementBodyText'] ?? '';

--- a/Classes/DataProcessing/ControlStructureProcessor.php
+++ b/Classes/DataProcessing/ControlStructureProcessor.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
 
 namespace Netresearch\UniversalMessenger\DataProcessing;
 
-use TYPO3\CMS\Core\Service\FlexFormService;
+use TYPO3\CMS\Core\Configuration\FlexForm\FlexFormTools;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 use TYPO3\CMS\Frontend\ContentObject\DataProcessorInterface;
@@ -51,13 +51,13 @@ class ControlStructureProcessor implements DataProcessorInterface
     }
 
     /**
-     * Returns the FlexForm service instance.
+     * Returns the FlexForm tools instance.
      *
-     * @return FlexFormService
+     * @return FlexFormTools
      */
-    private function getFlexFormService(): FlexFormService
+    private function getFlexFormTools(): FlexFormTools
     {
-        return GeneralUtility::makeInstance(FlexFormService::class);
+        return GeneralUtility::makeInstance(FlexFormTools::class);
     }
 
     /**
@@ -70,7 +70,7 @@ class ControlStructureProcessor implements DataProcessorInterface
     private function convertFlexFormContentToArray(string $flexFormContent): array
     {
         if ($flexFormContent !== '') {
-            return $this->getFlexFormService()
+            return $this->getFlexFormTools()
                 ->convertFlexFormContentToArray($flexFormContent);
         }
 


### PR DESCRIPTION
## Summary

`TYPO3\CMS\Core\Service\FlexFormService` exists in TYPO3 v14 only as a **legacy class alias** for `TYPO3\CMS\Core\Configuration\FlexForm\FlexFormTools` (`@deprecated since v14, removal in v15`). Switch both usages to the real class.

Closes #52.

## Change

- `Classes/Backend/EventListener/PageContentPreviewRenderingEventListener.php` — constructor DI now type-hints `FlexFormTools`.
- `Classes/DataProcessing/ControlStructureProcessor.php` — `GeneralUtility::makeInstance(FlexFormTools::class)`.
- Property/method renamed to match (`flexFormTools`, `getFlexFormTools()`).

`convertFlexFormContentToArray(string): array` is unchanged; the alias already resolved to the exact same `FlexFormTools` instance, so this is behaviourally identical.

## Quality

- `composer ci:test` green (phplint, PHPStan level 8, Rector, php-cs-fixer)
- Multi-reviewer audit loop (correctness, TYPO3 v14 migration, maintainability, project standards, general review) to two consecutive zero-finding rounds. Verified against the core `ClassAliasMap` (FlexFormService → FlexFormTools), that FlexFormTools is `#[Autoconfigure(public: true)]` (so the event-listener DI still resolves), and that no `FlexFormService` reference remains in the extension.
