### PR TITLE
refactor: remove the dead classic addService() registration (#53)

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -11,7 +11,6 @@ declare(strict_types=1);
 
 use Netresearch\UniversalMessenger\Configuration;
 use Netresearch\UniversalMessenger\Controller\NewsletterPreviewController;
-use Netresearch\UniversalMessenger\Service\UniversalMessengerService;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Utility\ExtensionUtility;
@@ -49,24 +48,6 @@ call_user_func(static function (): void {
     $GLOBALS['TYPO3_CONF_VARS']['BE']['defaultUserTSconfig'] = ($GLOBALS['TYPO3_CONF_VARS']['BE']['defaultUserTSconfig'] ?? '')
         . LF
         . 'options.pageTree.doktypesToShowInNewPageDragArea := addToList(' . $newsletterPageDokType . ')';
-
-    // Service
-    ExtensionManagementUtility::addService(
-        'universal_messenger',
-        'universal_messenger',
-        UniversalMessengerService::class,
-        [
-            'title'       => 'Universal Messenger API service',
-            'description' => 'Universal Messenger API service',
-            'subtype'     => '',
-            'available'   => true,
-            'priority'    => 50,
-            'quality'     => 50,
-            'os'          => '',
-            'exec'        => '',
-            'className'   => UniversalMessengerService::class,
-        ],
-    );
 
     ExtensionUtility::configurePlugin(
         'UniversalMessenger',


### PR DESCRIPTION
## Summary

`ext_localconf.php` registered `UniversalMessengerService` via `ExtensionManagementUtility::addService()` (the legacy `$GLOBALS['T3_SERVICES']` service-chain API). Nothing ever retrieves the service through that registry — it is consumed exclusively via constructor DI (`AbstractRepository`). The registration is dead code.

Closes #53.

## Change

`ext_localconf.php` — remove the `addService()` block and the now-unused `UniversalMessengerService` import. The service stays fully functional through `Configuration/Services.yaml` autowiring (it implements `SingletonInterface` and is injected into `AbstractRepository`).

## Quality

- `composer ci:test` green (phplint, PHPStan level 8, Rector, php-cs-fixer)
- Multi-reviewer audit loop (correctness, TYPO3 v14 migration, maintainability, project standards, general review) to two consecutive zero-finding rounds. Reviewers grep-confirmed no `makeInstanceService`/`$GLOBALS['T3_SERVICES']` usage anywhere in the extension, and that the container autowiring keeps the service resolvable.
