### PR TITLE
refactor: drop auto-managed system columns from ext_tables.sql (#54)

### DIFF
--- a/Classes/Domain/Model/NewsletterChannel.php
+++ b/Classes/Domain/Model/NewsletterChannel.php
@@ -35,11 +35,6 @@ class NewsletterChannel extends AbstractEntity
     protected ?DateTime $tstamp = null;
 
     /**
-     * @var bool
-     */
-    protected bool $deleted = false;
-
-    /**
      * @var string
      */
     protected string $channelId = '';
@@ -110,26 +105,6 @@ class NewsletterChannel extends AbstractEntity
     public function setTstamp(?DateTime $tstamp): NewsletterChannel
     {
         $this->tstamp = $tstamp;
-
-        return $this;
-    }
-
-    /**
-     * @return bool
-     */
-    public function isDeleted(): bool
-    {
-        return $this->deleted;
-    }
-
-    /**
-     * @param bool $deleted
-     *
-     * @return NewsletterChannel
-     */
-    public function setDeleted(bool $deleted): NewsletterChannel
-    {
-        $this->deleted = $deleted;
 
         return $this;
     }

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -29,13 +29,6 @@ CREATE TABLE tx_universalmessenger_domain_model_newsletterchannel
 (
     uid          int(10) UNSIGNED     NOT NULL AUTO_INCREMENT,
     pid          int(10) UNSIGNED     NOT NULL DEFAULT 0,
-    tstamp       int(10) UNSIGNED     NOT NULL DEFAULT 0,
-    crdate       int(10) UNSIGNED     NOT NULL DEFAULT 0,
-    deleted      smallint(5) UNSIGNED NOT NULL DEFAULT 0,
-    hidden       smallint(5) UNSIGNED NOT NULL DEFAULT 0,
-    starttime    int(10) UNSIGNED     NOT NULL DEFAULT 0,
-    endtime      int(10) UNSIGNED     NOT NULL DEFAULT 0,
-    sorting      int(10) UNSIGNED     NOT NULL DEFAULT 0,
 
     channel_id   varchar(255)         NOT NULL,
     title        varchar(255)         NOT NULL DEFAULT '',


### PR DESCRIPTION
## Summary

`ext_tables.sql` manually defined system columns that the TYPO3 schema analyzer now manages automatically (since v13, Feature-104311), plus two columns that the extension's TCA does not declare at all.

Closes #54.

## Change

`ext_tables.sql` — drop `tstamp, crdate, deleted, hidden, starttime, endtime, sorting` from `tx_universalmessenger_domain_model_newsletterchannel`, keeping `uid`, `pid`, the domain columns and the indexes.

| Column | Why it can go |
|---|---|
| `tstamp`, `crdate` | declared in TCA `ctrl` → auto-recreated as `int unsigned` (identical) |
| `sorting` | `ctrl.sortby` → auto-recreated (canonical signed int) |
| `starttime`, `endtime` | TCA `type=datetime` columns → auto-recreated (v14 canonical `bigint`) |
| `hidden`, `deleted` | not declared in the TCA at all (no `enablecolumns`, no `ctrl.delete` — records are hard-deleted) → genuinely unused |

Domain columns are kept explicit on purpose: the analyzer would auto-create them with slightly different semantics (e.g. `description` would become nullable), so keeping them avoids schema drift.

## Notes

On existing installs the schema analyzer will report the drops as destructive column removals requiring manual/CLI confirmation on deploy; the removed columns held only default values and are not read anywhere.

## Quality

- `composer ci:test` green (phplint, PHPStan level 8, Rector, php-cs-fixer)
- Multi-reviewer audit loop (correctness, TYPO3 v14 migration, maintainability, project standards, **data integrity**) to two consecutive zero-finding rounds. Reviewers traced each column through `DefaultTcaSchema::enrich()` and Extbase persistence, confirming the recreated columns match and that `hidden`/`deleted` are never persisted or queried (the orphan `$deleted` model property is dead code, never written).
