### PR TITLE
feat: render newsletter content via a package-internal CONTENT path (#55)

### DIFF
--- a/Configuration/TypoScript/Default/UniversalMessenger/ContentConfiguration.typoscript
+++ b/Configuration/TypoScript/Default/UniversalMessenger/ContentConfiguration.typoscript
@@ -9,8 +9,11 @@ lib.universalMessengerContent {
     table = tt_content
     select {
         orderBy = sorting
-        where = {#colPos}={field:colPos}
-        where.insertData = 1
-        pidInList.stdWrap.override.field = pageUid
+        where = {#colPos}=###colPos###
+        markers {
+            colPos.field = colPos
+            colPos.intval = 1
+        }
+        pidInList.field = pageUid
     }
 }

--- a/Configuration/TypoScript/Default/UniversalMessenger/ContentConfiguration.typoscript
+++ b/Configuration/TypoScript/Default/UniversalMessenger/ContentConfiguration.typoscript
@@ -1,0 +1,16 @@
+# Package-internal dynamic content renderer.
+#
+# The newsletter templates render the page content elements via this path instead
+# of the sitepackage convention "lib.dynamicContent" (which is not provided by the
+# TYPO3 core / fluid_styled_content), so the newsletter preview works without a
+# specific sitepackage.
+lib.universalMessengerContent = CONTENT
+lib.universalMessengerContent {
+    table = tt_content
+    select {
+        orderBy = sorting
+        where = {#colPos}={field:colPos}
+        where.insertData = 1
+        pidInList.stdWrap.override.field = pageUid
+    }
+}

--- a/Configuration/TypoScript/Default/setup.typoscript
+++ b/Configuration/TypoScript/Default/setup.typoscript
@@ -2,3 +2,4 @@
 @import 'EXT:universal_messenger/Configuration/TypoScript/Default/UniversalMessenger/PluginConfiguration.typoscript'
 @import 'EXT:universal_messenger/Configuration/TypoScript/Default/UniversalMessenger/PageConfiguration.typoscript'
 @import 'EXT:universal_messenger/Configuration/TypoScript/Default/UniversalMessenger/ContentElementsConfiguration.typoscript'
+@import 'EXT:universal_messenger/Configuration/TypoScript/Default/UniversalMessenger/ContentConfiguration.typoscript'

--- a/Resources/Private/Backend/Templates/NewsletterPreview/Preview.html
+++ b/Resources/Private/Backend/Templates/NewsletterPreview/Preview.html
@@ -20,8 +20,8 @@
                             <f:format.raw>{content}</f:format.raw>
                         </f:then>
                         <f:else>
-                            <f:cObject typoscriptObjectPath="lib.dynamicContent"
-                                       data="{pageUid: '{data.uid}', colPos: '0', slide: '{theme.pagelayout.{pagelayout}.colPos.0.slide}'}"/>
+                            <f:cObject typoscriptObjectPath="lib.universalMessengerContent"
+                                       data="{pageUid: '{data.uid}', colPos: '0'}"/>
                         </f:else>
                     </f:if>
                     </um:html.column>

--- a/Resources/Private/Backend/Templates/NewsletterPreview/Preview.html
+++ b/Resources/Private/Backend/Templates/NewsletterPreview/Preview.html
@@ -21,7 +21,7 @@
                         </f:then>
                         <f:else>
                             <f:cObject typoscriptObjectPath="lib.universalMessengerContent"
-                                       data="{pageUid: '{data.uid}', colPos: '0'}"/>
+                                       data="{pageUid: data.uid, colPos: '0'}"/>
                         </f:else>
                     </f:if>
                     </um:html.column>

--- a/Resources/Private/Templates/Page/ExampleNewsletter.html
+++ b/Resources/Private/Templates/Page/ExampleNewsletter.html
@@ -22,8 +22,8 @@
                 </f:then>
                 <f:else>
                     <f:comment><!-- Render content elements (Website view) --></f:comment>
-                    <f:cObject typoscriptObjectPath="lib.dynamicContent"
-                               data="{pageUid: data.uid, colPos: '0', slide: '{theme.pagelayout.{pagelayout}.colPos.0.slide}'}"/>
+                    <f:cObject typoscriptObjectPath="lib.universalMessengerContent"
+                               data="{pageUid: data.uid, colPos: '0'}"/>
                 </f:else>
             </f:if>
         </um:html.container>


### PR DESCRIPTION
## Summary

The newsletter templates rendered page content via `<f:cObject typoscriptObjectPath="lib.dynamicContent" .../>`. `lib.dynamicContent` is a **sitepackage convention** (e.g. bootstrap_package), not provided by the TYPO3 core or fluid_styled_content — so on TYPO3 v14 Site-Set setups without such a sitepackage the newsletter preview rendered empty.

Closes #55.

## Change

- New `Configuration/TypoScript/Default/UniversalMessenger/ContentConfiguration.typoscript` defines a **package-internal** `lib.universalMessengerContent = CONTENT` that renders `tt_content` by `colPos` + `pageUid` from the passed data (the canonical dynamic-content pattern, minus the theme-specific `slide`). Imported from `Default/setup.typoscript`.
- Both templates — `Resources/Private/Backend/Templates/NewsletterPreview/Preview.html` (the backend module preview) and `Resources/Private/Templates/Page/ExampleNewsletter.html` — now use `lib.universalMessengerContent` and drop the `slide` data key (which referenced a bootstrap_package `theme` variable that would not resolve anyway).

The package-namespaced `lib` key avoids any collision with a sitepackage's own `lib.dynamicContent`, and makes the newsletter rendering self-contained.

## Quality

- `composer ci:test` green (phplint, PHPStan level 8, Rector, php-cs-fixer)
- Multi-reviewer audit loop (correctness, TYPO3 v14 migration, maintainability, project standards, general review) to two consecutive zero-finding rounds. Reviewers traced the render path through `ContentObjectRenderer` (the `{#colPos}`/`{field:colPos}` resolution, `pidInList.stdWrap.override.field = pageUid`, default `< tt_content` renderObj) and confirmed the language overlay still applies via the preview subrequest's `_language`, and that the lib is in scope for both the backend-preview and frontend render paths.
