### PR TITLE
TYPO3 v14: drop deprecated doktypesToShowInNewPageDragArea registration (#61)

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ for sending via individual newsletter channels.
 > **Note (TYPO3 v14):** The newsletter page type appears in the page tree "new page"
 > drag area automatically. Administrators always see it; for non-admin editors it is
 > shown only when the `Newsletter` page type is enabled in their backend group under
-> `Access Rights → Page types`. Since TYPO3 v14.2 the drag area is derived from these
+> `Access Rights => Page types`. Since TYPO3 v14.2 the drag area is derived from these
 > group permissions — the former `options.pageTree.doktypesToShowInNewPageDragArea`
 > user TSconfig option was deprecated and is removed in v15.0. If your installation
 > still sets that option explicitly to a custom value, add the newsletter page type

--- a/README.md
+++ b/README.md
@@ -128,6 +128,16 @@ for sending via individual newsletter channels.
 ![Backend user configuration](Documentation/BackendUserConfiguration.png)
 *Fig. 4: Backend user configuration*
 
+> **Note (TYPO3 v14):** The newsletter page type appears in the page tree "new page"
+> drag area automatically. Administrators always see it; for non-admin editors it is
+> shown only when the `Newsletter` page type is enabled in their backend group under
+> `Access Rights → Page types`. Since TYPO3 v14.2 the drag area is derived from these
+> group permissions — the former `options.pageTree.doktypesToShowInNewPageDragArea`
+> user TSconfig option was deprecated and is removed in v15.0. If your installation
+> still sets that option explicitly to a custom value, add the newsletter page type
+> to that list, or (recommended) drop the deprecated option and grant the page type
+> via the group permission instead.
+
 
 ### TypoScript
 Go to the `TypoScript` page, select `Edit TypoScript Record` and then click `Edit the whole TypoScript record`. On the

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -9,10 +9,8 @@
 
 declare(strict_types=1);
 
-use Netresearch\UniversalMessenger\Configuration;
 use Netresearch\UniversalMessenger\Controller\NewsletterPreviewController;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Utility\ExtensionUtility;
 
 defined('TYPO3') || exit('Access denied.');
@@ -31,24 +29,15 @@ call_user_func(static function (): void {
         false,
     );
 
-    $configuration         = GeneralUtility::makeInstance(Configuration::class);
-    $newsletterPageDokType = $configuration->getNewsletterPageDokType();
-
-    // We need to add the following user TypoScript config to all users, so that the new
-    // page type is displayed in the wizard.
+    // The newsletter page type is registered in the page-type selector via
+    // Configuration/TCA/Overrides/pages.php (addTcaSelectItem). Since TYPO3 v14.2 the page
+    // tree "new page" drag area determines the selectable doktypes automatically from the
+    // backend user's group permissions (pagetypes_select) / admin status, so no explicit
+    // user TSconfig registration is needed anymore.
     //
-    // ExtensionManagementUtility::addUserTSConfig() was removed in TYPO3 v13, so we append
-    // to $GLOBALS['TYPO3_CONF_VARS']['BE']['defaultUserTSconfig'] directly. This is the
-    // supported way to register dynamic user TSconfig in TYPO3 v13+.
-    //
-    // In TYPO3 v14, the dynamic configuration must be rebuilt. Currently, you cannot access
-    // configured constants.typoscript in the user.tsconfig.
-    //
-    // See https://forge.typo3.org/issues/106069
-    $GLOBALS['TYPO3_CONF_VARS']['BE']['defaultUserTSconfig'] = ($GLOBALS['TYPO3_CONF_VARS']['BE']['defaultUserTSconfig'] ?? '')
-        . LF
-        . 'options.pageTree.doktypesToShowInNewPageDragArea := addToList(' . $newsletterPageDokType . ')';
-
+    // The former "options.pageTree.doktypesToShowInNewPageDragArea" user TSconfig option was
+    // deprecated in v14.2 and will be removed in v15.0 (see TYPO3 changelog #109196); setting
+    // it now only triggers a deprecation log while yielding the same, permission-gated result.
     ExtensionUtility::configurePlugin(
         'UniversalMessenger',
         'NewsletterPreview',


### PR DESCRIPTION
## Summary

The newsletter page type was force-registered into the page tree "new page" drag area by appending to `$GLOBALS['TYPO3_CONF_VARS']['BE']['defaultUserTSconfig']`:

```
options.pageTree.doktypesToShowInNewPageDragArea := addToList(<doktype>)
```

That user TSconfig option was **deprecated in TYPO3 v14.2 and will be removed in v15.0** (changelog #109196). With the option set to a non-default value, `TreeController::getDokTypes()` emits an `E_USER_DEPRECATED` log on every page-tree load.

Closes #61.

## Change

- **`ext_localconf.php`**: removed the `defaultUserTSconfig` append block (plus the now-unused `Configuration` / `GeneralUtility` imports and the `$configuration` / `$newsletterPageDokType` locals), replaced by an explanatory comment.
- **`README.md`**: documents the v14 behaviour and the migration path for installations that still set the deprecated option explicitly.

Since v14.2 the page tree determines the selectable doktypes automatically from the backend user's group permissions via `TreeController::getDokTypesByFormDataCompiler()` (→ `TcaSelectItems`). The newsletter doktype is already registered in the page-type selector through `Configuration/TCA/Overrides/pages.php` (`addTcaSelectItem`), so it now appears in the drag area automatically — for admins always, and for editors whose group allows the page type (`pagetypes_select`). This is the **same permission-gated result** as before (the old `getDokTypesByTsConfig()` path also intersected with `pagetypes_select`), just without the deprecation.

This also removes the obsolete forge #106069 concern: the doktype value was always resolved in PHP from the extension configuration, never from a TypoScript constant in user TSconfig.

## Edge case (documented, not code-fixable)

If an installation still explicitly sets `options.pageTree.doktypesToShowInNewPageDragArea` to a custom value, core routes those users to the deprecated path that uses only that explicit list (no admin bypass), so the newsletter type would be absent there. This is inherent to the core deprecation (re-adding the option would only re-trigger the deprecation and be removed in v15). The README documents the migration: add the type to that list, or drop the deprecated option and grant the page type via the group permission.

## Quality

- `composer ci:test` green (phplint, PHPStan level 8, Rector dry-run, php-cs-fixer).
- Multi-reviewer audit loop (TYPO3 v14, correctness, architecture, maintainability, project standards) to **two consecutive zero-finding rounds**, verified against the real TYPO3 v14.3.4 core source (`TreeController`, `AbstractItemProvider::removeItemsByDoktypeUserRestriction`, Changelog 14.2 Deprecation-109196).
