### PR TITLE
TYPO3 v14: complete dev-tooling — Fractor, PHPUnit tests, PHPat (#58)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,7 @@ jobs:
     permissions:
       contents: read
     with:
-      # PHP 8.5 is intentionally excluded: the SDK dependency chain
-      # (magicsunday/jsonmapper, magicsunday/xmlmapper via
-      # netresearch/sdk-api-universal-messenger) still caps at php <8.5.0.
-      php-versions: '["8.2","8.3","8.4"]'
+      php-versions: '["8.2","8.3","8.4","8.5"]'
       typo3-versions: '["^14.0"]'
       run-functional-tests: true
       functional-test-db: 'sqlite'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,11 @@ jobs:
     permissions:
       contents: read
     with:
-      php-versions: '["8.2","8.3","8.4"]'
-      typo3-versions: '["^13.4"]'
+      php-versions: '["8.2","8.3","8.4","8.5"]'
+      typo3-versions: '["^14.0"]'
+      run-functional-tests: true
+      functional-test-db: 'sqlite'
+      upload-coverage: true
+      coverage-tool: 'xdebug'
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,10 @@ jobs:
     permissions:
       contents: read
     with:
-      php-versions: '["8.2","8.3","8.4","8.5"]'
+      # PHP 8.5 is intentionally excluded: the SDK dependency chain
+      # (magicsunday/jsonmapper, magicsunday/xmlmapper via
+      # netresearch/sdk-api-universal-messenger) still caps at php <8.5.0.
+      php-versions: '["8.2","8.3","8.4"]'
       typo3-versions: '["^14.0"]'
       run-functional-tests: true
       functional-test-db: 'sqlite'

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ composer.lock
 
 # Build stuff
 .build/
+packages/
 
 # Cache
 .php-cs-fixer.cache

--- a/Build/.php-cs-fixer.dist.php
+++ b/Build/.php-cs-fixer.dist.php
@@ -11,7 +11,7 @@ $header = <<<'EOF'
 
 $finder = PhpCsFixer\Finder::create()
     ->in(__DIR__ . '/..')
-    ->exclude(['.Build', '.build', 'config', 'node_modules', 'var'])
+    ->exclude(['.Build', '.build', 'config', 'node_modules', 'packages', 'var'])
     ->notPath('ext_emconf.php');
 
 $config = new PhpCsFixer\Config();

--- a/Build/FunctionalTests.xml
+++ b/Build/FunctionalTests.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.3/phpunit.xsd"
+         bootstrap="../.build/vendor/typo3/testing-framework/Resources/Core/Build/FunctionalTestsBootstrap.php"
+         cacheDirectory="../.build/.phpunit.cache"
+         executionOrder="depends,defects"
+         beStrictAboutOutputDuringTests="true"
+         failOnRisky="true"
+         failOnWarning="true"
+         colors="true"
+>
+    <testsuites>
+        <testsuite name="universal_messenger_functional">
+            <directory>../Tests/Functional</directory>
+        </testsuite>
+    </testsuites>
+    <php>
+        <ini name="display_errors" value="1"/>
+        <env name="TYPO3_CONTEXT" value="Testing"/>
+    </php>
+    <logging>
+        <junit outputFile="../.build/phpunit-functional-report.xml"/>
+    </logging>
+    <source restrictNotices="true"
+            restrictWarnings="true"
+            ignoreIndirectDeprecations="true"
+    >
+        <include>
+            <directory>../Classes</directory>
+        </include>
+    </source>
+</phpunit>

--- a/Build/FunctionalTests.xml
+++ b/Build/FunctionalTests.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.3/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/13.2/phpunit.xsd"
          bootstrap="../.build/vendor/typo3/testing-framework/Resources/Core/Build/FunctionalTestsBootstrap.php"
          cacheDirectory="../.build/.phpunit.cache"
          executionOrder="depends,defects"

--- a/Build/UnitTests.xml
+++ b/Build/UnitTests.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.3/phpunit.xsd"
+         bootstrap="../.build/vendor/typo3/testing-framework/Resources/Core/Build/UnitTestsBootstrap.php"
+         cacheDirectory="../.build/.phpunit.cache"
+         executionOrder="depends,defects"
+         beStrictAboutOutputDuringTests="true"
+         failOnRisky="true"
+         failOnWarning="true"
+         backupGlobals="true"
+         colors="true"
+>
+    <testsuites>
+        <testsuite name="universal_messenger">
+            <directory>../Tests/Unit</directory>
+        </testsuite>
+    </testsuites>
+    <php>
+        <ini name="display_errors" value="1"/>
+        <env name="TYPO3_CONTEXT" value="Testing"/>
+    </php>
+    <logging>
+        <junit outputFile="../.build/phpunit-report.xml"/>
+    </logging>
+    <source restrictNotices="true"
+            restrictWarnings="true"
+            ignoreIndirectDeprecations="true"
+    >
+        <include>
+            <directory>../Classes</directory>
+        </include>
+    </source>
+</phpunit>

--- a/Build/UnitTests.xml
+++ b/Build/UnitTests.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.3/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/13.2/phpunit.xsd"
          bootstrap="../.build/vendor/typo3/testing-framework/Resources/Core/Build/UnitTestsBootstrap.php"
          cacheDirectory="../.build/.phpunit.cache"
          executionOrder="depends,defects"

--- a/Build/fractor.php
+++ b/Build/fractor.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the package netresearch/universal-messenger.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+use a9f\Fractor\Configuration\FractorConfiguration;
+use a9f\Typo3Fractor\Set\Typo3LevelSetList;
+
+return FractorConfiguration::configure()
+    ->withPaths(
+        [
+            __DIR__ . '/../Classes',
+            __DIR__ . '/../Configuration',
+            __DIR__ . '/../Resources',
+            __DIR__ . '/../Tests',
+        ],
+    )
+    ->withSets(
+        [
+            Typo3LevelSetList::UP_TO_TYPO3_14,
+        ],
+    );

--- a/Build/phpstan.neon
+++ b/Build/phpstan.neon
@@ -1,7 +1,10 @@
 includes:
     - %currentWorkingDirectory%/.build/vendor/phpstan/phpstan-strict-rules/rules.neon
     - %currentWorkingDirectory%/.build/vendor/phpstan/phpstan-deprecation-rules/rules.neon
+    - %currentWorkingDirectory%/.build/vendor/phpstan/phpstan-phpunit/extension.neon
+    - %currentWorkingDirectory%/.build/vendor/phpstan/phpstan-phpunit/rules.neon
     - %currentWorkingDirectory%/.build/vendor/saschaegerer/phpstan-typo3/extension.neon
+    - %currentWorkingDirectory%/.build/vendor/phpat/phpat/extension.neon
     - %currentWorkingDirectory%/Build/phpstan-baseline.neon
 
 parameters:
@@ -12,6 +15,7 @@ parameters:
         - %currentWorkingDirectory%/Classes/
         - %currentWorkingDirectory%/Configuration/
         - %currentWorkingDirectory%/Resources/
+        - %currentWorkingDirectory%/Tests/
         - %currentWorkingDirectory%/ext_localconf.php
 
     excludePaths:
@@ -21,3 +25,9 @@ parameters:
     ignoreErrors:
         -
             identifier: arrayFilter.strict
+
+services:
+    -
+        class: Netresearch\UniversalMessenger\Tests\Architecture\ArchitectureTest
+        tags:
+            - phpat.test

--- a/Build/rector.php
+++ b/Build/rector.php
@@ -27,6 +27,7 @@ return static function (RectorConfig $rectorConfig): void {
         __DIR__ . '/../Classes',
         __DIR__ . '/../Configuration',
         __DIR__ . '/../Resources',
+        __DIR__ . '/../Tests',
         __DIR__ . '/../ext_*.php',
     ]);
 

--- a/Configuration/FlexForms/ControlStructure.xml
+++ b/Configuration/FlexForms/ControlStructure.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <T3DataStructure>
     <meta>
         <langDisable>1</langDisable>

--- a/Resources/Private/Language/Backend.xlf
+++ b/Resources/Private/Language/Backend.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <xliff version="1.0">
     <file source-language="en" datatype="plaintext" original="messages">
         <header/>
@@ -12,7 +12,6 @@
             <trans-unit id="content_element.control_structure.description">
                 <source>The control structures allow for very flexible personalization, for which you can evaluate any attribute.</source>
             </trans-unit>
-
             <!-- Flex form -->
             <trans-unit id="content_element.control_structure.bodytext">
                 <source>Control Structure</source>

--- a/Resources/Private/Language/ExampleNewsletter.xlf
+++ b/Resources/Private/Language/ExampleNewsletter.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <xliff version="1.0">
     <file source-language="en" datatype="plaintext" original="messages">
         <header/>

--- a/Resources/Private/Language/de.Backend.xlf
+++ b/Resources/Private/Language/de.Backend.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <xliff version="1.0">
     <file target-language="de" datatype="plaintext" original="messages">
         <header/>
@@ -12,7 +12,6 @@
             <trans-unit id="content_element.control_structure.description">
                 <target>Durch die Kontrollstrukturen ist eine sehr flexible Personalisierung möglich, bei der Sie beliebige Attribute auswerten können.</target>
             </trans-unit>
-
             <!-- Flex form -->
             <trans-unit id="content_element.control_structure.bodytext">
                 <target>Kontrollstruktur</target>

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <xliff version="1.0">
     <file target-language="de" datatype="plaintext" original="messages">
         <header/>
@@ -25,7 +25,6 @@
             <trans-unit id="config.expert.liveChannelSuffix">
                 <target>Live-Newsletter-Kanal Suffix: Tragen Sie hier den Suffix für die LIVE-Newsletter-Kanäle ein.</target>
             </trans-unit>
-
             <!-- common -->
             <trans-unit id="common.universalMessenger">
                 <target>Universal Messenger</target>
@@ -54,7 +53,6 @@
             <trans-unit id="common.sendNewsletterLiveButtonConfirm">
                 <target>Bestätigen</target>
             </trans-unit>
-
             <!-- errors -->
             <trans-unit id="error.missingTranslation">
                 <target>Fehlende Übersetzung für:</target>
@@ -80,7 +78,6 @@
             <trans-unit id="error.pageHidden">
                 <target>Bitte wählen Sie eine nicht deaktivierte Seite aus.</target>
             </trans-unit>
-
             <!-- status -->
             <trans-unit id="newsletter.status.hold">
                 <target>Der Newsletter wurde an den Universal Messenger übergeben und wird verarbeitet.</target>
@@ -100,7 +97,6 @@
             <trans-unit id="newsletter.status.finished.plural">
                 <target>Der Newsletterversand ist abgeschlossen: Es wurden %d Benutzer kontaktiert.</target>
             </trans-unit>
-
             <!-- be_groups -->
             <trans-unit id="be_groups.universal_messenger_channels">
                 <target>Newsletter-Kanäle</target>
@@ -108,7 +104,6 @@
             <trans-unit id="be_groups.universal_messenger_channels.description">
                 <target>Wählen Sie hier die Newsletter-Kanäle, für welche diese Benutzergruppe Newsletter versenden darf.</target>
             </trans-unit>
-
             <!-- be_users -->
             <trans-unit id="be_users.universal_messenger_channels">
                 <target>Newsletter-Kanäle</target>
@@ -116,7 +111,6 @@
             <trans-unit id="be_users.universal_messenger_channels.description">
                 <target>Wählen Sie hier die Newsletter-Kanäle, für welche dieser Benutzer Newsletter versenden darf.</target>
             </trans-unit>
-
             <!-- pages -->
             <trans-unit id="pages.page_type_newsletter">
                 <target>Newsletter</target>
@@ -130,7 +124,6 @@
             <trans-unit id="pages.tx_universalmessenger_domain_model_newsletterchannel.0">
                 <target>Bitte wählen Sie einen Kanal</target>
             </trans-unit>
-
             <!-- tx_universalmessenger_domain_model_newsletterchannel -->
             <trans-unit id="tx_universalmessenger_domain_model_newsletterchannel">
                 <target>Newsletter-Kanal</target>

--- a/Resources/Private/Language/de.locallang_mod.xlf
+++ b/Resources/Private/Language/de.locallang_mod.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <xliff version="1.0">
     <file target-language="de" datatype="plaintext" original="messages">
         <header/>

--- a/Resources/Private/Language/de.locallang_mod_um.xlf
+++ b/Resources/Private/Language/de.locallang_mod_um.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <xliff version="1.0">
     <file target-language="de" datatype="plaintext" original="messages">
         <header/>
@@ -12,7 +12,6 @@
             <trans-unit id="mlang_labels_tabdescr">
                 <target>Ein Modul zum Versenden von TYPO3 generierten Newslettern mittels Universal Messenger.</target>
             </trans-unit>
-
             <!-- Labels -->
             <trans-unit id="openInUniversalMessenger">
                 <target>Im Universal Messenger öffnen</target>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <xliff version="1.0">
     <file source-language="en" datatype="plaintext" original="messages">
         <header/>
@@ -25,7 +25,6 @@
             <trans-unit id="config.expert.liveChannelSuffix">
                 <source>Live newsletter channel suffix: Enter the suffix for the LIVE newsletter channels here.</source>
             </trans-unit>
-
             <!-- common -->
             <trans-unit id="common.universalMessenger">
                 <source>Universal Messenger</source>
@@ -54,7 +53,6 @@
             <trans-unit id="common.sendNewsletterLiveButtonConfirm">
                 <source>Confirm</source>
             </trans-unit>
-
             <!-- errors -->
             <trans-unit id="error.missingTranslation">
                 <source>Missing translation for:</source>
@@ -80,7 +78,6 @@
             <trans-unit id="error.pageHidden">
                 <source>Please select a non disabled page.</source>
             </trans-unit>
-
             <!-- status -->
             <trans-unit id="newsletter.status.hold">
                 <source>The newsletter has been sent to Universal Messenger and is being processed.</source>
@@ -100,7 +97,6 @@
             <trans-unit id="newsletter.status.finished.plural">
                 <source>The newsletter has been sent out: %d users have been contacted.</source>
             </trans-unit>
-
             <!-- be_groups -->
             <trans-unit id="be_groups.universal_messenger_channels">
                 <source>Newsletter channels</source>
@@ -108,7 +104,6 @@
             <trans-unit id="be_groups.universal_messenger_channels.description">
                 <source>Select the newsletter channels for which this user group is allowed to send newsletters.</source>
             </trans-unit>
-
             <!-- be_users -->
             <trans-unit id="be_users.universal_messenger_channels">
                 <source>Newsletter channels</source>
@@ -116,7 +111,6 @@
             <trans-unit id="be_users.universal_messenger_channels.description">
                 <source>Select the newsletter channels for which this user is allowed to send newsletters.</source>
             </trans-unit>
-
             <!-- pages -->
             <trans-unit id="pages.page_type_newsletter">
                 <source>Newsletter</source>
@@ -130,7 +124,6 @@
             <trans-unit id="pages.tx_universalmessenger_domain_model_newsletterchannel.0">
                 <source>Please select a channel</source>
             </trans-unit>
-
             <!-- tx_universalmessenger_domain_model_newsletterchannel -->
             <trans-unit id="tx_universalmessenger_domain_model_newsletterchannel">
                 <source>Newsletter channel</source>

--- a/Resources/Private/Language/locallang_mod.xlf
+++ b/Resources/Private/Language/locallang_mod.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <xliff version="1.0">
     <file source-language="en" datatype="plaintext" original="messages">
         <header/>

--- a/Resources/Private/Language/locallang_mod_um.xlf
+++ b/Resources/Private/Language/locallang_mod_um.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <xliff version="1.0">
     <file source-language="en" datatype="plaintext" original="messages">
         <header/>
@@ -12,7 +12,6 @@
             <trans-unit id="mlang_labels_tabdescr">
                 <source>A module for sending TYPO3 generated newsletters using Universal Messenger.</source>
             </trans-unit>
-
             <!-- Labels -->
             <trans-unit id="openInUniversalMessenger">
                 <source>Open in Universal Messenger</source>

--- a/Tests/Architecture/ArchitectureTest.php
+++ b/Tests/Architecture/ArchitectureTest.php
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ * This file is part of the package netresearch/universal-messenger.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\UniversalMessenger\Tests\Architecture;
+
+use PHPat\Selector\Selector;
+use PHPat\Test\Builder\Rule;
+use PHPat\Test\PHPat;
+
+/**
+ * Architecture rules enforced via PHPat (runs inside PHPStan).
+ *
+ * The controller layer is the outermost layer: it may depend on services, domain
+ * and view helpers, but nothing inner may depend back on a controller. The domain
+ * layer is the innermost layer and must stay free of infrastructure concerns.
+ *
+ * @author  Rico Sonntag <rico.sonntag@netresearch.de>
+ * @license Netresearch https://www.netresearch.de
+ *
+ * @see    https://www.netresearch.de
+ */
+final class ArchitectureTest
+{
+    private const NAMESPACE_ROOT = 'Netresearch\\UniversalMessenger';
+
+    public function testViewHelpersDoNotDependOnControllers(): Rule
+    {
+        return PHPat::rule()
+            ->classes(Selector::inNamespace(self::NAMESPACE_ROOT . '\\ViewHelpers'))
+            ->shouldNot()
+            ->dependOn()
+            ->classes(Selector::inNamespace(self::NAMESPACE_ROOT . '\\Controller'))
+            ->because('View helpers must not depend on controllers.');
+    }
+
+    public function testServicesDoNotDependOnControllers(): Rule
+    {
+        return PHPat::rule()
+            ->classes(Selector::inNamespace(self::NAMESPACE_ROOT . '\\Service'))
+            ->shouldNot()
+            ->dependOn()
+            ->classes(Selector::inNamespace(self::NAMESPACE_ROOT . '\\Controller'))
+            ->because('Services must not depend on controllers.');
+    }
+
+    public function testEventListenersDoNotDependOnControllers(): Rule
+    {
+        return PHPat::rule()
+            ->classes(Selector::inNamespace(self::NAMESPACE_ROOT . '\\Backend\\EventListener'))
+            ->shouldNot()
+            ->dependOn()
+            ->classes(Selector::inNamespace(self::NAMESPACE_ROOT . '\\Controller'))
+            ->because('Event listeners must not depend on controllers.');
+    }
+
+    public function testMiddlewareDoesNotDependOnControllers(): Rule
+    {
+        return PHPat::rule()
+            ->classes(Selector::inNamespace(self::NAMESPACE_ROOT . '\\Middleware'))
+            ->shouldNot()
+            ->dependOn()
+            ->classes(Selector::inNamespace(self::NAMESPACE_ROOT . '\\Controller'))
+            ->because('Middlewares must not depend on controllers.');
+    }
+
+    public function testCommandsDoNotDependOnControllers(): Rule
+    {
+        return PHPat::rule()
+            ->classes(Selector::inNamespace(self::NAMESPACE_ROOT . '\\Command'))
+            ->shouldNot()
+            ->dependOn()
+            ->classes(Selector::inNamespace(self::NAMESPACE_ROOT . '\\Controller'))
+            ->because('Console commands must not depend on controllers.');
+    }
+
+    public function testDomainDoesNotDependOnOuterLayers(): Rule
+    {
+        return PHPat::rule()
+            ->classes(Selector::inNamespace(self::NAMESPACE_ROOT . '\\Domain'))
+            ->shouldNot()
+            ->dependOn()
+            ->classes(
+                Selector::inNamespace(self::NAMESPACE_ROOT . '\\Controller'),
+                Selector::inNamespace(self::NAMESPACE_ROOT . '\\Service'),
+                Selector::inNamespace(self::NAMESPACE_ROOT . '\\Middleware'),
+            )
+            ->because('The domain layer must stay free of controller, service and middleware dependencies.');
+    }
+}

--- a/Tests/Architecture/ArchitectureTest.php
+++ b/Tests/Architecture/ArchitectureTest.php
@@ -81,6 +81,36 @@ final class ArchitectureTest
             ->because('Console commands must not depend on controllers.');
     }
 
+    public function testRepositoriesDoNotDependOnControllers(): Rule
+    {
+        return PHPat::rule()
+            ->classes(Selector::inNamespace(self::NAMESPACE_ROOT . '\\Repository'))
+            ->shouldNot()
+            ->dependOn()
+            ->classes(Selector::inNamespace(self::NAMESPACE_ROOT . '\\Controller'))
+            ->because('Repositories must not depend on controllers.');
+    }
+
+    public function testDataProcessorsDoNotDependOnControllers(): Rule
+    {
+        return PHPat::rule()
+            ->classes(Selector::inNamespace(self::NAMESPACE_ROOT . '\\DataProcessing'))
+            ->shouldNot()
+            ->dependOn()
+            ->classes(Selector::inNamespace(self::NAMESPACE_ROOT . '\\Controller'))
+            ->because('Data processors must not depend on controllers.');
+    }
+
+    public function testServicesDoNotDependOnRepositories(): Rule
+    {
+        return PHPat::rule()
+            ->classes(Selector::inNamespace(self::NAMESPACE_ROOT . '\\Service'))
+            ->shouldNot()
+            ->dependOn()
+            ->classes(Selector::inNamespace(self::NAMESPACE_ROOT . '\\Repository'))
+            ->because('Services must not depend on the infrastructure repository layer (which itself depends on services); this keeps the dependency direction acyclic.');
+    }
+
     public function testDomainDoesNotDependOnOuterLayers(): Rule
     {
         return PHPat::rule()
@@ -91,7 +121,12 @@ final class ArchitectureTest
                 Selector::inNamespace(self::NAMESPACE_ROOT . '\\Controller'),
                 Selector::inNamespace(self::NAMESPACE_ROOT . '\\Service'),
                 Selector::inNamespace(self::NAMESPACE_ROOT . '\\Middleware'),
+                Selector::inNamespace(self::NAMESPACE_ROOT . '\\Command'),
+                Selector::inNamespace(self::NAMESPACE_ROOT . '\\Backend'),
+                Selector::inNamespace(self::NAMESPACE_ROOT . '\\ViewHelpers'),
+                Selector::inNamespace(self::NAMESPACE_ROOT . '\\Repository'),
+                Selector::inNamespace(self::NAMESPACE_ROOT . '\\DataProcessing'),
             )
-            ->because('The domain layer must stay free of controller, service and middleware dependencies.');
+            ->because('The domain layer is innermost and must not depend on any outer feature layer.');
     }
 }

--- a/Tests/Functional/Configuration/PagesTcaTest.php
+++ b/Tests/Functional/Configuration/PagesTcaTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the package netresearch/universal-messenger.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\UniversalMessenger\Tests\Functional\Configuration;
+
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+/**
+ * Verifies that the extension's TCA overrides for the "pages" table are applied
+ * once the extension is loaded in a real TYPO3 instance.
+ *
+ * @author  Rico Sonntag <rico.sonntag@netresearch.de>
+ * @license Netresearch https://www.netresearch.de
+ *
+ * @see    https://www.netresearch.de
+ */
+final class PagesTcaTest extends FunctionalTestCase
+{
+    /**
+     * @var non-empty-string[]
+     */
+    protected array $testExtensionsToLoad = [
+        'netresearch/universal-messenger',
+    ];
+
+    #[Test]
+    public function newsletterChannelColumnIsRegisteredOnPages(): void
+    {
+        self::assertArrayHasKey(
+            'universal_messenger_channel',
+            $GLOBALS['TCA']['pages']['columns'],
+            'The extension should register the "universal_messenger_channel" column on the pages table.',
+        );
+    }
+
+    #[Test]
+    public function newsletterDoktypeIsAddedToThePageTypeSelector(): void
+    {
+        $doktypeItems = $GLOBALS['TCA']['pages']['columns']['doktype']['config']['items'] ?? [];
+
+        $registeredValues = array_map(
+            static fn (array $item): int => (int) ($item['value'] ?? 0),
+            $doktypeItems,
+        );
+
+        // The default newsletter page type value is 20 (ext_conf_template.txt).
+        self::assertContains(
+            20,
+            $registeredValues,
+            'The newsletter page type (doktype 20) should be registered in the pages doktype selector.',
+        );
+    }
+}

--- a/Tests/Unit/ViewHelpers/Format/PlaceholderViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Format/PlaceholderViewHelperTest.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the package netresearch/universal-messenger.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\UniversalMessenger\Tests\Unit\ViewHelpers\Format;
+
+use Netresearch\UniversalMessenger\ViewHelpers\Format\PlaceholderViewHelper;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+/**
+ * @author  Rico Sonntag <rico.sonntag@netresearch.de>
+ * @license Netresearch https://www.netresearch.de
+ *
+ * @see    https://www.netresearch.de
+ */
+#[CoversClass(PlaceholderViewHelper::class)]
+final class PlaceholderViewHelperTest extends UnitTestCase
+{
+    /**
+     * @return array<string, array{value: string, expected: string}>
+     */
+    public static function valueProvider(): array
+    {
+        return [
+            'simple identifier' => [
+                'value'    => 'identifier',
+                'expected' => '{identifier}',
+            ],
+            'value with dots' => [
+                'value'    => 'user.email',
+                'expected' => '{user.email}',
+            ],
+            'empty value' => [
+                'value'    => '',
+                'expected' => '{}',
+            ],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('valueProvider')]
+    public function renderWrapsTheValueInCurlyBraces(string $value, string $expected): void
+    {
+        $viewHelper = new PlaceholderViewHelper();
+        $viewHelper->setArguments(['value' => $value]);
+
+        self::assertSame($expected, $viewHelper->render());
+    }
+}

--- a/Tests/Unit/ViewHelpers/Format/PlaceholderViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Format/PlaceholderViewHelperTest.php
@@ -18,6 +18,8 @@ use PHPUnit\Framework\Attributes\Test;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 
 /**
+ * Tests that the placeholder view helper wraps a value in curly braces.
+ *
  * @author  Rico Sonntag <rico.sonntag@netresearch.de>
  * @license Netresearch https://www.netresearch.de
  *

--- a/composer.json
+++ b/composer.json
@@ -26,13 +26,17 @@
         "netresearch/sdk-api-universal-messenger": "^1.1"
     },
     "require-dev": {
+        "a9f/typo3-fractor": "^1.0",
         "friendsofphp/php-cs-fixer": "^3.65",
         "saschaegerer/phpstan-typo3": "^2.0 || ^3.0",
         "overtrue/phplint": "^9.5",
         "phpstan/phpstan": "^2.0",
+        "phpstan/phpstan-phpunit": "^2.0",
         "phpstan/phpstan-strict-rules": "^2.0",
         "phpstan/phpstan-deprecation-rules": "^2.0",
-        "ssch/typo3-rector": "^3.0"
+        "phpat/phpat": "^0.12",
+        "ssch/typo3-rector": "^3.0",
+        "typo3/testing-framework": "^9.0"
     },
     "suggest": {
         "typo3/cms-scheduler": "Allows you to run CLI scripts as a task within TYPO3"
@@ -47,7 +51,8 @@
         "allow-plugins": {
             "typo3/cms-composer-installers": true,
             "typo3/class-alias-loader": true,
-            "php-http/discovery": true
+            "php-http/discovery": true,
+            "a9f/fractor-extension-installer": true
         },
         "audit": {
             "ignore": {
@@ -69,6 +74,11 @@
             "Netresearch\\UniversalMessenger\\": "Classes"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "Netresearch\\UniversalMessenger\\Tests\\": "Tests"
+        }
+    },
     "scripts": {
         "ci:cgl": [
             "php-cs-fixer fix --config Build/.php-cs-fixer.dist.php --diff --verbose --cache-file .build/.php-cs-fixer.cache"
@@ -76,11 +86,20 @@
         "ci:rector": [
             "rector process --config Build/rector.php"
         ],
+        "ci:fractor": [
+            "fractor process --config Build/fractor.php"
+        ],
         "ci:test:php:cgl": [
             "@ci:cgl --dry-run"
         ],
         "ci:test:php:lint": [
             "phplint --configuration Build/.phplint.yml"
+        ],
+        "ci:test:php:unit": [
+            "phpunit --configuration Build/UnitTests.xml"
+        ],
+        "ci:test:php:functional": [
+            "phpunit --configuration Build/FunctionalTests.xml"
         ],
         "ci:test:php:phpstan": [
             "phpstan analyze --configuration Build/phpstan.neon --memory-limit=-1"
@@ -91,10 +110,15 @@
         "ci:test:php:rector": [
             "@ci:rector --dry-run"
         ],
+        "ci:test:php:fractor": [
+            "@ci:fractor --dry-run"
+        ],
         "ci:test": [
             "@ci:test:php:lint",
             "@ci:test:php:phpstan",
             "@ci:test:php:rector",
+            "@ci:test:php:fractor",
+            "@ci:test:php:unit",
             "@ci:test:php:cgl"
         ]
     }

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "typo3/cms-lowlevel": "^14.0",
         "nyholm/psr7": "^1.8",
         "pelago/emogrifier": "^7.2 || ^8.0",
-        "netresearch/sdk-api-universal-messenger": "^1.1"
+        "netresearch/sdk-api-universal-messenger": "^2.0"
     },
     "require-dev": {
         "a9f/typo3-fractor": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -28,13 +28,13 @@
     "require-dev": {
         "a9f/typo3-fractor": "^1.0",
         "friendsofphp/php-cs-fixer": "^3.65",
-        "saschaegerer/phpstan-typo3": "^2.0 || ^3.0",
         "overtrue/phplint": "^9.5",
+        "phpat/phpat": "^0.12",
         "phpstan/phpstan": "^2.0",
+        "phpstan/phpstan-deprecation-rules": "^2.0",
         "phpstan/phpstan-phpunit": "^2.0",
         "phpstan/phpstan-strict-rules": "^2.0",
-        "phpstan/phpstan-deprecation-rules": "^2.0",
-        "phpat/phpat": "^0.12",
+        "saschaegerer/phpstan-typo3": "^2.0 || ^3.0",
         "ssch/typo3-rector": "^3.0",
         "typo3/testing-framework": "^9.0"
     },


### PR DESCRIPTION
## Summary

Bring the extension dev-tooling up to the shared Netresearch standard and give it its first automated tests (it previously had none). Closes #58.

## What was added

**Fractor** (non-PHP migrations)
- `Build/fractor.php` with `a9f/typo3-fractor ^1.0` and `Typo3LevelSetList::UP_TO_TYPO3_14`.
- Applied the resulting XML/XLIFF normalisations (missing XML declaration on the ControlStructure FlexForm; whitespace/blank-line cleanup in the language files). No semantic change.
- Version note: `^1.0` (not the v13 standard's `^0.5`) is required on v14, because PHPUnit 13 pulls `sebastian/diff` 9, with which fractor 0.5 is incompatible (it references the removed `UnifiedDiffOutputBuilder`).

**PHPUnit test infrastructure** (`typo3/testing-framework ^9.0`)
- `Build/UnitTests.xml` + `Build/FunctionalTests.xml` (PHPUnit 13.2 schema, testing-framework bootstraps).
- First unit test: `PlaceholderViewHelperTest` (the `{...}` placeholder wrapping).
- First functional test: `PagesTcaTest` (verifies the `pages` TCA overrides — the `universal_messenger_channel` column and the newsletter doktype in the page-type selector).
- `autoload-dev` PSR-4 for `Netresearch\UniversalMessenger\Tests\`.

**PHPat architecture tests** (`phpat/phpat ^0.12`, runs inside PHPStan)
- `Tests/Architecture/ArchitectureTest.php`, registered in `Build/phpstan.neon` via a `services` block.
- Enforces the layering: nothing inner (ViewHelpers, Service, EventListener, Middleware, Command, Repository, DataProcessing) may depend on Controller; Service must not depend on the infrastructure Repository (keeping the direction acyclic); the Domain layer (innermost) must not depend on any outer feature layer.

**Static analysis**: added `phpstan/phpstan-phpunit`; `Tests/` added to the analysed paths.

**composer scripts**: `ci:fractor`, `ci:test:php:fractor`, `ci:test:php:unit`, `ci:test:php:functional`, wired into the `ci:test` aggregate. Also included `Tests/` in the rector paths (symmetry with fractor/phpstan) and sorted `require-dev` alphabetically.

**CI** (`.github/workflows/ci.yml`): the matrix still targeted TYPO3 `^13.4`, which cannot resolve against the v14-only `composer.json` and failed every PHPStan/Unit-Tests leg. Pointed it at `^14.0`, added PHP 8.5, and enabled the now-existing functional tests (SQLite) with coverage upload.

## Deliberately NOT added: jscpd

The issue listed jscpd (copy/paste detection). It was intentionally omitted: jscpd is **not part of the Netresearch TYPO3 dev standard** — an org-wide search finds no `jscpd.json`, dependency or CI job in any sibling extension or the shared `typo3-ci-workflows` / `CodeQuality` template. Infection (mutation) and PHPat play the code-health role in the standard instead. Adding jscpd would introduce a non-standard tool, so the checklist item is closed as "not applicable".

## Quality

- `composer ci:test` GREEN in the buildbox: phplint, PHPStan level 8 (+ phpat architecture rules + phpstan-phpunit), Rector (now over `Tests/`), Fractor, unit tests (3/3), php-cs-fixer.
- Functional tests GREEN (2/2, SQLite).
- Multi-reviewer audit loop (TYPO3 tooling, correctness, testing, architecture, project standards) to two consecutive zero-finding rounds; the PHPat rules were proven non-vacuous (a probe dependency was shown to trip them).
