### PR TITLE
[BUGFIX] Show a clear message when the module TypoScript/site set is missing

### DIFF
--- a/Classes/Controller/UniversalMessengerController.php
+++ b/Classes/Controller/UniversalMessengerController.php
@@ -46,6 +46,7 @@ use TYPO3\CMS\Core\Site\SiteFinder;
 use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Http\ForwardResponse;
+use TYPO3Fluid\Fluid\View\Exception\InvalidTemplateResourceException;
 
 /**
  * UniversalMessengerController.
@@ -214,7 +215,19 @@ class UniversalMessengerController extends AbstractBaseController implements Log
         $this->view->assign('previewUrl', $newsletterUrl);
         $this->view->assign('newsletterChannel', $newsletterChannel);
 
-        $this->moduleTemplate->assign('content', $this->view->render());
+        // The module content is rendered through the Extbase view, whose template paths
+        // come from the extension TypoScript (module.tx_universalmessenger.view). When that
+        // TypoScript is not loaded — e.g. the "netresearch/universal-messenger" site set is
+        // not assigned to the current site — the view falls back to the Extbase default path
+        // and cannot resolve its template. Catch that case and show an actionable message
+        // instead of letting the raw Fluid exception surface to the editor.
+        try {
+            $renderedContent = $this->view->render();
+        } catch (InvalidTemplateResourceException) {
+            return $this->forwardFlashMessage('error.missingTypoScriptConfiguration');
+        }
+
+        $this->moduleTemplate->assign('content', $renderedContent);
 
         return $this->moduleTemplate->renderResponse('Backend/UniversalMessenger');
     }

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -75,6 +75,9 @@
             <trans-unit id="error.missingChannelConfiguration">
                 <target>Bitte wählen Sie einen gültigen Newsletter-Kanal in den Seiteneigenschaften aus.</target>
             </trans-unit>
+            <trans-unit id="error.missingTypoScriptConfiguration">
+                <target>Die TypoScript-Konfiguration von Universal Messenger ist nicht geladen. Bitte weisen Sie der Site das Site-Set „Universal Messenger“ zu (oder binden Sie die statische TypoScript-Vorlage der Erweiterung ein).</target>
+            </trans-unit>
             <trans-unit id="error.pageHidden">
                 <target>Bitte wählen Sie eine nicht deaktivierte Seite aus.</target>
             </trans-unit>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -75,6 +75,9 @@
             <trans-unit id="error.missingChannelConfiguration">
                 <source>Please select a valid newsletter channel in the page properties.</source>
             </trans-unit>
+            <trans-unit id="error.missingTypoScriptConfiguration">
+                <source>The Universal Messenger TypoScript configuration is not loaded. Please assign the "Universal Messenger" site set to this site (or include the extension's static TypoScript template).</source>
+            </trans-unit>
             <trans-unit id="error.pageHidden">
                 <source>Please select a non disabled page.</source>
             </trans-unit>


### PR DESCRIPTION
## Problem
Wählt man im Backend-Modul „Universal Messenger" eine gültige Newsletter-Seite (doktype 20, Kanal gesetzt, sichtbar, berechtigt), rendert `UniversalMessengerController::indexAction()` den Inhalt über `$this->view->render()`. Dessen Template-Pfade stammen aus dem Extension-TypoScript (`module.tx_universalmessenger.view` => `Resources/Private/Backend/Templates/`). Ist dieses TypoScript nicht geladen — etwa weil das Site Set `netresearch/universal-messenger` der Site nicht zugewiesen ist — fällt die View auf den Extbase-Default `Resources/Private/Templates/` zurück und wirft eine rohe `TYPO3Fluid\\Fluid\\View\\Exception\\InvalidTemplateResourceException` ("Whoops, looks like something went wrong").

## Lösung
`$this->view->render()` wird in try/catch gekapselt; bei `InvalidTemplateResourceException` wird über das bestehende `forwardFlashMessage()`-Muster eine verständliche, handlungsleitende Meldung (`error.missingTypoScriptConfiguration`, EN+DE) ausgegeben. `errorAction()` rendert über `moduleTemplate->renderResponse('Backend/UniversalMessenger')` und funktioniert auch ohne die Modul-View-Pfade.

## Verifikation (echtes v14-Backend, PHP 8.4)
- **Ohne Site Set:** Modul zeigt jetzt die FlashMessage statt der Exception. ✓
- **Mit Site Set:** normaler Betrieb unverändert (Kanal-UI, Vorschau, Versand-Buttons) — keine Regression. ✓

Gefunden bei der v14-Backend-Verifikation (LOOE-14).

Resolves #77