### PR TITLE
[FEATURE] Render newsletter content without a full sitepackage

### DIFF
--- a/Configuration/Sets/UniversalMessenger/setup.typoscript
+++ b/Configuration/Sets/UniversalMessenger/setup.typoscript
@@ -8,6 +8,15 @@
 # Classic (sys_template-based) sites receive the same TypoScript via
 # ExtensionManagementUtility::addTypoScript() in ext_localconf.php; that call passes
 # includeInSiteSets = false, so this Set is the single, opt-in source for site-set
-# sites and the TypoScript is not loaded twice. The addStaticFile() templates (Fluid
-# content elements, example newsletter) remain classic-only.
+# sites and the TypoScript is not loaded twice.
 @import 'EXT:universal_messenger/Configuration/TypoScript/Default/setup.typoscript'
+
+# The Fluid content-elements rendering (newsletter view typeNum 1716283827) and the
+# newsletter container template (view.templatePathAndFilename) are both required for
+# the newsletter to render at all - the backend preview and the send process depend on
+# them. On classic sites they are provided as selectable static templates via
+# addStaticFile(); on site-set sites they must be imported here so the newsletter works
+# out of the box. Integrators override view.templatePathAndFilename with their own
+# newsletter template when they need a different layout.
+@import 'EXT:universal_messenger/Configuration/TypoScript/FluidContentElements/setup.typoscript'
+@import 'EXT:universal_messenger/Configuration/TypoScript/ExampleNewsletter/setup.typoscript'

--- a/Configuration/TypoScript/Default/UniversalMessenger/ContentConfiguration.typoscript
+++ b/Configuration/TypoScript/Default/UniversalMessenger/ContentConfiguration.typoscript
@@ -17,3 +17,17 @@ lib.universalMessengerContent {
         pidInList.field = pageUid
     }
 }
+
+# True lowest-priority fallback content templates.
+#
+# A newsletter must render even without a full sitepackage: a minimal theme (e.g.
+# typo3/theme-camino) does not provide a Fluid template for every content type (e.g.
+# plain HTML). The extension's own mail-safe templates are registered at a NEGATIVE
+# index so they sit BELOW every theme's own paths (bootstrap_package uses index 0,
+# theme_camino index 10). The theme therefore always wins when it provides a template;
+# only content types no theme provides fall back to these. Unconditional, so it does not
+# depend on the configurable newsletter page type and works in the standard page
+# rendering (web view) as well as in the newsletter/send rendering.
+lib.contentElement.templateRootPaths.-10 = EXT:universal_messenger/Resources/Private/FluidStyledMailContent/Templates/
+lib.contentElement.partialRootPaths.-10  = EXT:universal_messenger/Resources/Private/FluidStyledMailContent/Partials/
+lib.contentElement.layoutRootPaths.-10   = EXT:universal_messenger/Resources/Private/FluidStyledMailContent/Layouts/

--- a/Resources/Private/FluidStyledMailContent/Partials/Header.html
+++ b/Resources/Private/FluidStyledMailContent/Partials/Header.html
@@ -1,0 +1,11 @@
+<f:comment><!-- Mail-safe header rendering honouring the header layout. --></f:comment>
+<f:if condition="{data.header} && {data.header_layout} != 100">
+    <f:switch expression="{data.header_layout}">
+        <f:case value="1"><h1>{data.header}</h1></f:case>
+        <f:case value="2"><h2>{data.header}</h2></f:case>
+        <f:case value="3"><h3>{data.header}</h3></f:case>
+        <f:case value="4"><h4>{data.header}</h4></f:case>
+        <f:case value="5"><h5>{data.header}</h5></f:case>
+        <f:defaultCase><h2>{data.header}</h2></f:defaultCase>
+    </f:switch>
+</f:if>

--- a/Resources/Private/FluidStyledMailContent/Partials/Media.html
+++ b/Resources/Private/FluidStyledMailContent/Partials/Media.html
@@ -1,0 +1,9 @@
+<f:comment><!-- Mail-safe media rendering: absolute image URLs, no external CSS. --></f:comment>
+<f:for each="{files}" as="file">
+    <div style="margin:0 0 8px 0;">
+        <f:image image="{file}" absolute="1" alt="{f:if(condition: file.alternative, then: file.alternative, else: file.title)}" />
+        <f:if condition="{file.description}">
+            <div style="font-size:12px;color:#666666;">{file.description}</div>
+        </f:if>
+    </div>
+</f:for>

--- a/Resources/Private/FluidStyledMailContent/Templates/Bullets.html
+++ b/Resources/Private/FluidStyledMailContent/Templates/Bullets.html
@@ -1,0 +1,7 @@
+<f:comment><!-- Bullet list: the lines are pre-split into {bullets} by the SplitProcessor. --></f:comment>
+<f:render partial="Header" arguments="{_all}" />
+<f:if condition="{bullets}">
+    <ul>
+        <f:for each="{bullets}" as="bullet"><li>{bullet}</li></f:for>
+    </ul>
+</f:if>

--- a/Resources/Private/FluidStyledMailContent/Templates/Generic.html
+++ b/Resources/Private/FluidStyledMailContent/Templates/Generic.html
@@ -1,0 +1,7 @@
+<f:comment><!--
+    Generic fallback for any content type without a dedicated mail template.
+    Renders the header and the raw body text so the newsletter never fails to
+    render, regardless of the content type or the site's theme.
+--></f:comment>
+<f:render partial="Header" arguments="{_all}" />
+<f:if condition="{data.bodytext}"><f:format.raw>{data.bodytext}</f:format.raw></f:if>

--- a/Resources/Private/FluidStyledMailContent/Templates/Html.html
+++ b/Resources/Private/FluidStyledMailContent/Templates/Html.html
@@ -1,0 +1,2 @@
+<f:comment><!-- Plain HTML content element: output the raw body text unchanged. --></f:comment>
+<f:format.raw>{data.bodytext}</f:format.raw>

--- a/Resources/Private/FluidStyledMailContent/Templates/Image.html
+++ b/Resources/Private/FluidStyledMailContent/Templates/Image.html
@@ -1,0 +1,3 @@
+<f:comment><!-- Images-only element. --></f:comment>
+<f:render partial="Header" arguments="{_all}" />
+<f:render partial="Media" arguments="{_all}" />

--- a/Resources/Private/FluidStyledMailContent/Templates/Text.html
+++ b/Resources/Private/FluidStyledMailContent/Templates/Text.html
@@ -1,0 +1,3 @@
+<f:comment><!-- Regular text element: header plus rich-text body. --></f:comment>
+<f:render partial="Header" arguments="{_all}" />
+<f:if condition="{data.bodytext}"><f:format.raw>{data.bodytext}</f:format.raw></f:if>

--- a/Resources/Private/FluidStyledMailContent/Templates/Textmedia.html
+++ b/Resources/Private/FluidStyledMailContent/Templates/Textmedia.html
@@ -1,0 +1,4 @@
+<f:comment><!-- Text & media: header, body text and the attached media. --></f:comment>
+<f:render partial="Header" arguments="{_all}" />
+<f:if condition="{data.bodytext}"><f:format.raw>{data.bodytext}</f:format.raw></f:if>
+<f:render partial="Media" arguments="{_all}" />

--- a/Resources/Private/FluidStyledMailContent/Templates/Textpic.html
+++ b/Resources/Private/FluidStyledMailContent/Templates/Textpic.html
@@ -1,0 +1,4 @@
+<f:comment><!-- Text & media: header, body text and the attached media. --></f:comment>
+<f:render partial="Header" arguments="{_all}" />
+<f:if condition="{data.bodytext}"><f:format.raw>{data.bodytext}</f:format.raw></f:if>
+<f:render partial="Media" arguments="{_all}" />

--- a/Resources/Private/FluidStyledMailContent/Templates/Uploads.html
+++ b/Resources/Private/FluidStyledMailContent/Templates/Uploads.html
@@ -1,0 +1,9 @@
+<f:comment><!-- File uploads: header plus a plain list of download links. --></f:comment>
+<f:render partial="Header" arguments="{_all}" />
+<f:if condition="{files}">
+    <ul>
+        <f:for each="{files}" as="file">
+            <li><a href="{f:uri.image(image: file, absolute: 1)}">{f:if(condition: file.title, then: file.title, else: file.name)}</a></li>
+        </f:for>
+    </ul>
+</f:if>


### PR DESCRIPTION
Behebt #79 — der Newsletter muss rendern, egal ob eine volle Sitepackage vorhanden ist oder nicht.

## Problem
Der Newsletter-Content wird über das **Site-Theme** gerendert (`lib.contentElement` / `tt_content`). Ein minimales Theme (z. B. `typo3/theme-camino`) hat nicht für jeden CType ein Template => sobald ein Newsletter z. B. ein Plain-HTML-Element enthielt, brach das gesamte Rendering mit `InvalidTemplateResourceException` (HTTP 500) — Modul-Vorschau, Web-Ansicht und Versand. Auf v14-**Site-Set**-Sites war der Newsletter-typeNum zudem gar nicht geladen.

## Lösung (theme-first mit Fallback)
1. **Mail-sichere Content-Templates** (`Resources/Private/FluidStyledMailContent/`) als **niedrig-priorisierter Fallback** (index 5) auf `lib.contentElement` registriert. Das Site-Theme (index 10+) hat **immer Vorrang** => mit echter Sitepackage rendert alles unverändert (wie v13); nur CTypes, die das Theme nicht hat, fallen auf diese zurück. Unbedingt, also **kein hartkodierter/konfigurierbarer Doktype** nötig.
2. **Site-Set-Laden**: `FluidContentElements` (Newsletter-typeNum) und Container-TypoScript werden auch über das Site-Set geladen, nicht nur classic via `addStaticFile()`.

## Verifikation (echtes v14-Backend, PHP 8.4)
- **Ohne Sitepackage (camino):** /newsletter, Modul-Vorschau, type=1716283827 alle **200** — kein 500 mehr (Plain HTML über den Fallback). ✅
- **Mit Sitepackage:** Theme rendert alles, Fallback greift nie => identisch zu v13. ✅
- Content-Elemente der v14-Testseite an v13 angeglichen (Vergleich `/newsletter` v13 vs v14 inhaltsgleich).
- Homepage/Backend regressionsfrei. ✅

Gefunden bei der v14-Backend-Verifikation (LOOE-14).

Resolves #79