### PR TITLE
feat: adopt SDK v3 HTTP basic auth (add apiSecret configuration)

### DIFF
--- a/Classes/Backend/EventListener/ModifyBlindedConfigurationOptionsEventListener.php
+++ b/Classes/Backend/EventListener/ModifyBlindedConfigurationOptionsEventListener.php
@@ -34,9 +34,10 @@ final class ModifyBlindedConfigurationOptionsEventListener
     {
         $blindedConfigurationOptions = $event->getBlindedConfigurationOptions();
 
-        // Blind API key
+        // Blind API key and secret
         if ($event->getProviderIdentifier() === 'confVars') {
-            $blindedConfigurationOptions['TYPO3_CONF_VARS']['EXTENSIONS']['universal_messenger']['apiKey'] = '******';
+            $blindedConfigurationOptions['TYPO3_CONF_VARS']['EXTENSIONS']['universal_messenger']['apiKey']    = '******';
+            $blindedConfigurationOptions['TYPO3_CONF_VARS']['EXTENSIONS']['universal_messenger']['apiSecret'] = '******';
         }
 
         $event->setBlindedConfigurationOptions($blindedConfigurationOptions);

--- a/Classes/Service/UniversalMessengerService.php
+++ b/Classes/Service/UniversalMessengerService.php
@@ -67,6 +67,7 @@ class UniversalMessengerService implements SingletonInterface
             $this->logger,
             $webserviceConfiguration->getApiBaseUrl(),
             $webserviceConfiguration->getApiKey(),
+            $webserviceConfiguration->getApiSecret(),
         );
     }
 

--- a/Classes/WebserviceConfiguration.php
+++ b/Classes/WebserviceConfiguration.php
@@ -29,11 +29,18 @@ class WebserviceConfiguration
     private readonly string $apiBaseUrl;
 
     /**
-     * The API key.
+     * The public API key (basic auth username).
      *
      * @var string
      */
     private readonly string $apiKey;
+
+    /**
+     * The secret API key (basic auth password).
+     *
+     * @var string
+     */
+    private readonly string $apiSecret;
 
     /**
      * WebserviceConfiguration constructor.
@@ -43,6 +50,7 @@ class WebserviceConfiguration
     ) {
         $this->apiBaseUrl = $configuration->getExtensionSetting('apiUrl') ?? '';
         $this->apiKey     = $configuration->getExtensionSetting('apiKey') ?? '';
+        $this->apiSecret  = $configuration->getExtensionSetting('apiSecret') ?? '';
     }
 
     /**
@@ -59,5 +67,13 @@ class WebserviceConfiguration
     public function getApiKey(): string
     {
         return $this->apiKey;
+    }
+
+    /**
+     * @return string
+     */
+    public function getApiSecret(): string
+    {
+        return $this->apiSecret;
     }
 }

--- a/README.md
+++ b/README.md
@@ -52,16 +52,21 @@ global structure `TYPO3_CONF_VARS` under `EXTENSIONS` and `universal_messenger` 
 $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['universal_messenger'] = array_merge(
     $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['universal_messenger'] ?? [],
     [
-        'apiUrl' => 'YOUR-API-URL',
-        'apiKey' => 'YOUR-API-KEY',
+        'apiUrl'    => 'YOUR-API-URL',
+        'apiKey'    => 'YOUR-API-KEY',
+        'apiSecret' => 'YOUR-API-SECRET',
     ]
 );
 ```
 
-| Field  | Description                                                                                                                        |
-|:-------|:-----------------------------------------------------------------------------------------------------------------------------------|
-| apiUrl | Your general Universal Messenger API URL, which is the basis of all requests, e.g. https://your-domain.td.universal-messenger.de/p |
-| apiKey | Your Universal Messenger API key                                                                                                   |
+The webservice authenticates via HTTP basic authentication. Create an API key in the Universal Messenger
+backend; it consists of a public key (used as the username) and a secret key (used as the password).
+
+| Field     | Description                                                                                                                        |
+|:----------|:-----------------------------------------------------------------------------------------------------------------------------------|
+| apiUrl    | Your general Universal Messenger API URL, which is the basis of all requests, e.g. https://your-domain.td.universal-messenger.de/p |
+| apiKey    | The public key of your Universal Messenger API key (basic auth username)                                                           |
+| apiSecret | The secret key of your Universal Messenger API key (basic auth password)                                                           |
 
 
 ### Extension configuration

--- a/Tests/Unit/WebserviceConfigurationTest.php
+++ b/Tests/Unit/WebserviceConfigurationTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the package netresearch/universal-messenger.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\UniversalMessenger\Tests\Unit;
+
+use Netresearch\UniversalMessenger\Configuration;
+use Netresearch\UniversalMessenger\WebserviceConfiguration;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+/**
+ * Tests that the webservice configuration exposes the API URL, key and secret.
+ *
+ * @author  Rico Sonntag <rico.sonntag@netresearch.de>
+ * @license Netresearch https://www.netresearch.de
+ *
+ * @see    https://www.netresearch.de
+ */
+#[CoversClass(WebserviceConfiguration::class)]
+final class WebserviceConfigurationTest extends UnitTestCase
+{
+    #[Test]
+    public function exposesTheConfiguredWebserviceCredentials(): void
+    {
+        $configuration = self::createStub(Configuration::class);
+        $configuration
+            ->method('getExtensionSetting')
+            ->willReturnMap([
+                ['apiUrl', 'https://example.org/p'],
+                ['apiKey', 'public-key'],
+                ['apiSecret', 'secret-key'],
+            ]);
+
+        $subject = new WebserviceConfiguration($configuration);
+
+        self::assertSame('https://example.org/p', $subject->getApiBaseUrl());
+        self::assertSame('public-key', $subject->getApiKey());
+        self::assertSame('secret-key', $subject->getApiSecret());
+    }
+
+    #[Test]
+    public function fallsBackToEmptyStringsWhenNothingIsConfigured(): void
+    {
+        $configuration = self::createStub(Configuration::class);
+        $configuration
+            ->method('getExtensionSetting')
+            ->willReturn(null);
+
+        $subject = new WebserviceConfiguration($configuration);
+
+        self::assertSame('', $subject->getApiBaseUrl());
+        self::assertSame('', $subject->getApiKey());
+        self::assertSame('', $subject->getApiSecret());
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "typo3/cms-lowlevel": "^14.0",
         "nyholm/psr7": "^1.8",
         "pelago/emogrifier": "^7.2 || ^8.0",
-        "netresearch/sdk-api-universal-messenger": "^2.0"
+        "netresearch/sdk-api-universal-messenger": "^3.0"
     },
     "require-dev": {
         "a9f/typo3-fractor": "^1.0",


### PR DESCRIPTION
## Summary

The Universal Messenger REST API migrated from the deprecated `umopen` API token to API keys authenticated via HTTP basic auth (public key + secret key). The SDK was updated accordingly in netresearch/sdk-api-universal-messenger#32 and released as **3.0.0**. This PR adopts the new SDK and provides the secret key to it.

## Changes

- Require `netresearch/sdk-api-universal-messenger: ^3.0`.
- Add an `apiSecret` extension setting (basic auth password) next to the existing `apiKey` (now the public key / basic auth username).
- Read `apiSecret` in `WebserviceConfiguration` and pass it to the SDK `UniversalMessenger` constructor.
- Blind `apiSecret` in the low-level configuration module (like `apiKey`).
- Document `apiSecret` and the basic-auth key model in the README.

## Testing

- Verified end-to-end against the live UM test system: the backend module lists channels and the test dispatch authenticates and submits the event via HTTP basic auth.

Closes #81
