### PR TITLE
docs: note Universal Messenger server compatibility for basic auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ backend; it consists of a public key (used as the username) and a secret key (us
 | apiKey    | The public key of your Universal Messenger API key (basic auth username)                                                           |
 | apiSecret | The secret key of your Universal Messenger API key (basic auth password)                                                           |
 
+> **Server compatibility:** the Universal Messenger REST API is not versioned on the client side — the
+> authentication scheme depends on the Universal Messenger server version. API-key basic authentication
+> requires a Universal Messenger server **after 7.40**. Older servers use the `umopen`/`cmsbs.open` token
+> and require the `2.x` line of this extension (and of the underlying
+> [SDK](https://github.com/netresearch/sdk-api-universal-messenger)).
+
 
 ### Extension configuration
 Open the `Settings` page under the `Admin Tools` section and switch to the `Extension Configuration`. Open the

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ backend; it consists of a public key (used as the username) and a secret key (us
 | apiKey    | The public key of your Universal Messenger API key (basic auth username)                                                           |
 | apiSecret | The secret key of your Universal Messenger API key (basic auth password)                                                           |
 
-> **Server compatibility:** the Universal Messenger REST API is not versioned on the client side — the
+> **Server compatibility:** The Universal Messenger REST API is not versioned on the client side — the
 > authentication scheme depends on the Universal Messenger server version. API-key basic authentication
 > requires a Universal Messenger server **after 7.40**. Older servers use the `umopen`/`cmsbs.open` token
 > and require the `2.x` line of this extension (and of the underlying


### PR DESCRIPTION
Follow-up to #82. Adds a short compatibility note to the webservice configuration section of the README: API-key basic authentication requires a Universal Messenger server after 7.40; older `umopen`/`cmsbs.open` servers require the 2.x line of the extension and SDK. The REST API is not versioned client-side.

Closes #83