### PR TITLE
docs: correct server compatibility note (basic auth requires UM 7.56.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ backend; it consists of a public key (used as the username) and a secret key (us
 
 > **Server compatibility:** The Universal Messenger REST API is not versioned on the client side — the
 > authentication scheme depends on the Universal Messenger server version. API-key basic authentication
-> requires a Universal Messenger server **after 7.40**. Older servers use the `umopen`/`cmsbs.open` token
-> and require the `2.x` line of this extension (and of the underlying
-> [SDK](https://github.com/netresearch/sdk-api-universal-messenger)).
+> requires a Universal Messenger server **7.56.0 or later**. The `umopen`/`cmsbs.open` token is deprecated
+> since UM 7.41 and works only transitionally; older servers use it and require the `2.x` line of this
+> extension (and of the underlying [SDK](https://github.com/netresearch/sdk-api-universal-messenger)).
 
 
 ### Extension configuration


### PR DESCRIPTION
Closes #85

## Was

README-Kompatibilitätshinweis korrigiert: API-Schlüssel-Basisauthentifizierung erfordert einen Universal-Messenger-Server **ab 7.56.0** (statt bisher „after 7.40").

## Warum

Beim Durchlesen des UM-7.64-Handbuchs bestätigte sich die genaue Versionsgrenze. Der `umopen`/`open`-Token ist seit 7.41 überholt und funktioniert nur übergangsweise; ab 7.56.0 ist ein API-Schlüssel erforderlich. Analoge Korrektur zu netresearch/sdk-api-universal-messenger#36.

## Hinweis

Reine Dokumentationsänderung.