### PR TITLE
ci: skip the docs.typo3.org verification until docs exist

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,5 +18,10 @@ jobs:
       archive-prefix: 'universal-messenger'
       package-name: 'netresearch/universal-messenger'
       extension-key: 'universal_messenger'
+      # Documentation/ holds only screenshots — no guides.xml, no RST — so
+      # docs.typo3.org never renders this extension (the URL 404s) and the
+      # verification waits for a render run that never appears. Remove this
+      # once real documentation exists: see issue #90.
+      skip-docs: true
     secrets:
       TYPO3_TER_ACCESS_TOKEN: ${{ secrets.TYPO3_TER_ACCESS_TOKEN }}


### PR DESCRIPTION
Refs #90

## Problem

Der Release-Lauf für `v3.0.0` ist rot, obwohl TER, Packagist, Signatur und GitHub-Release alle erfolgreich waren. Ursache ist ausschließlich die Doku-Prüfung:

```
No render run for 'Render netresearch/universal-messenger' appeared
within 180s — Intercept webhook may not have fired.
```

`Documentation/` enthält nur Bildschirmfotos, **keine `guides.xml` und keine RST-Quellen**. `docs.typo3.org/p/netresearch/universal-messenger/main/en-us/` liefert 404, der Webhook löst keinen Bau aus, der Job wartet vergeblich. Das würde bei **jedem** Release erneut passieren.

## Änderung

`skip-docs: true` im Aufruf des zentralen Release-Workflows, mit Kommentar und Verweis auf #90.

## Hinweis

Zwischenlösung. Sobald über #90 eine echte Dokumentation existiert, wird die Zeile wieder entfernt.