### PR TITLE
fix: never send a newsletter from a replayable request

### DIFF
--- a/Classes/Controller/UniversalMessengerController.php
+++ b/Classes/Controller/UniversalMessengerController.php
@@ -297,6 +297,15 @@ class UniversalMessengerController extends AbstractBaseController implements Log
      */
     public function createAction(?NewsletterChannel $newsletterChannel): ResponseInterface
     {
+        // Sending is irreversible and must never be reachable by navigation alone.
+        // A GET carrying the send parameters can be bookmarked and reloaded, and —
+        // worst of all — TYPO3 replays such a pending action after the editor logs
+        // in again, which would fire a live send without ever asking. Only an
+        // explicitly submitted form may reach the webservice.
+        if ($this->request->getMethod() !== 'POST') {
+            return $this->forwardFlashMessage('error.sendNotConfirmed');
+        }
+
         // Check if the submitted request is valid
         if (!$newsletterChannel instanceof NewsletterChannel
             || !$this->request->hasArgument('send')

--- a/Resources/Private/Backend/Templates/UniversalMessenger/Index.html
+++ b/Resources/Private/Backend/Templates/UniversalMessenger/Index.html
@@ -35,22 +35,48 @@
                 <h3 class="panel-title"><f:translate key="common.newsletterSend" /></h3>
             </div>
             <div class="panel-body">
-                <f:link.action
-                        class="btn btn-success btn-lg"
-                        action="create"
-                        additionalParams="{newsletterChannel: newsletterChannel, send: 'test'}"
-                >
-                    <f:translate key="common.sendNewsletterTest" />
-                </f:link.action>
+                <!--
+                    Both sends are submitted forms, never links. A link would put the
+                    send parameters into a URL that can be bookmarked, reloaded and —
+                    worst of all — replayed by TYPO3 after the editor logs in again,
+                    firing an irreversible live send without asking. The controller
+                    rejects anything that is not a POST.
+                -->
+                <f:form action="create" method="post" class="d-inline">
+                    <f:form.hidden name="newsletterChannel" value="{newsletterChannel.uid}" />
+                    <f:form.hidden name="send" value="test" />
+                    <button type="submit" class="btn btn-success btn-lg">
+                        <f:translate key="common.sendNewsletterTest" />
+                    </button>
+                </f:form>
 
-                <f:link.action
-                        class="btn btn-danger btn-lg float-end t3js-modal-trigger{f:if(condition: disableLiveButton, then: ' disabled')}"
-                        action="create"
-                        additionalParams="{newsletterChannel: newsletterChannel, send: 'live'}"
-                        data="{severity: 'error', title: '{f:translate(key: \'common.sendNewsletterLive\')}', bs-content: '{f:translate(key: \'common.sendNewsletterLiveDialogContent\', arguments: {0: newsletterChannel.title})}', button-close-text: '{f:translate(key: \'common.sendNewsletterLiveButtonCancel\')}', button-ok-text: '{f:translate(key: \'common.sendNewsletterLiveButtonConfirm\')}'}"
-                >
-                    <f:translate key="common.sendNewsletterLive" />
-                </f:link.action>
+                <f:form action="create" method="post" class="d-inline float-end">
+                    <f:form.hidden name="newsletterChannel" value="{newsletterChannel.uid}" />
+                    <f:form.hidden name="send" value="live" />
+                    <f:if condition="{disableLiveButton}">
+                        <f:then>
+                            <button type="submit" class="btn btn-danger btn-lg" disabled="disabled">
+                                <f:translate key="common.sendNewsletterLive" />
+                            </button>
+                        </f:then>
+                        <f:else>
+                            <!--
+                                The core modal trigger submits the owning form once the
+                                editor confirms, so the dialog keeps working without any
+                                custom JavaScript. Note "content" — v14 dropped support
+                                for the legacy "bs-content" attribute and would otherwise
+                                fall back to a generic confirmation text.
+                            -->
+                            <button
+                                    type="submit"
+                                    class="btn btn-danger btn-lg t3js-modal-trigger"
+                                    data="{severity: 'error', title: '{f:translate(key: \'common.sendNewsletterLive\')}', content: '{f:translate(key: \'common.sendNewsletterLiveDialogContent\', arguments: {0: newsletterChannel.title})}', button-close-text: '{f:translate(key: \'common.sendNewsletterLiveButtonCancel\')}', button-ok-text: '{f:translate(key: \'common.sendNewsletterLiveButtonConfirm\')}'}"
+                            >
+                                <f:translate key="common.sendNewsletterLive" />
+                            </button>
+                        </f:else>
+                    </f:if>
+                </f:form>
             </div>
         </div>
     </f:section>

--- a/Resources/Private/Backend/Templates/UniversalMessenger/Index.html
+++ b/Resources/Private/Backend/Templates/UniversalMessenger/Index.html
@@ -50,27 +50,33 @@
                     </button>
                 </f:form>
 
-                <f:form action="create" method="post" class="d-inline float-end">
+                <f:form action="create" method="post" class="d-inline float-end" id="universal-messenger-send-live">
                     <f:form.hidden name="newsletterChannel" value="{newsletterChannel.uid}" />
                     <f:form.hidden name="send" value="live" />
                     <f:if condition="{disableLiveButton}">
                         <f:then>
-                            <button type="submit" class="btn btn-danger btn-lg" disabled="disabled">
+                            <button type="button" class="btn btn-danger btn-lg" disabled="disabled">
                                 <f:translate key="common.sendNewsletterLive" />
                             </button>
                         </f:then>
                         <f:else>
                             <!--
-                                The core modal trigger submits the owning form once the
-                                editor confirms, so the dialog keeps working without any
-                                custom JavaScript. Note "content" — v14 dropped support
-                                for the legacy "bs-content" attribute and would otherwise
-                                fall back to a generic confirmation text.
+                                Deliberately type="button" and not type="submit": a submit
+                                button would send the newsletter straight away should the
+                                backend JavaScript be missing or broken, skipping the
+                                confirmation entirely. As a plain button it does nothing
+                                without JavaScript, and the core modal trigger submits the
+                                form named in "target-form" once the editor confirms — so
+                                the irreversible action always fails closed.
+
+                                Note "content": v14 dropped the legacy "bs-content"
+                                attribute and would otherwise show a generic text instead
+                                of the warning naming the channel.
                             -->
                             <button
-                                    type="submit"
+                                    type="button"
                                     class="btn btn-danger btn-lg t3js-modal-trigger"
-                                    data="{severity: 'error', title: '{f:translate(key: \'common.sendNewsletterLive\')}', content: '{f:translate(key: \'common.sendNewsletterLiveDialogContent\', arguments: {0: newsletterChannel.title})}', button-close-text: '{f:translate(key: \'common.sendNewsletterLiveButtonCancel\')}', button-ok-text: '{f:translate(key: \'common.sendNewsletterLiveButtonConfirm\')}'}"
+                                    data="{severity: 'error', title: '{f:translate(key: \'common.sendNewsletterLive\')}', content: '{f:translate(key: \'common.sendNewsletterLiveDialogContent\', arguments: {0: newsletterChannel.title})}', button-close-text: '{f:translate(key: \'common.sendNewsletterLiveButtonCancel\')}', button-ok-text: '{f:translate(key: \'common.sendNewsletterLiveButtonConfirm\')}', target-form: 'universal-messenger-send-live'}"
                             >
                                 <f:translate key="common.sendNewsletterLive" />
                             </button>

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -69,6 +69,9 @@
             <trans-unit id="error.invalidRequest">
                 <target>Die übermittelte Anfrage ist ungültig.</target>
             </trans-unit>
+            <trans-unit id="error.sendNotConfirmed">
+                <target>Der Newsletter wurde nicht versendet. Zur Sicherheit muss ein Versand unmittelbar in diesem Modul bestätigt werden — er wird nie automatisch nachgeholt, etwa nach einer erneuten Anmeldung. Bitte wählen Sie den Kanal aus und bestätigen Sie den Versand erneut.</target>
+            </trans-unit>
             <trans-unit id="error.exceptionDuringCreate">
                 <target>Bei der Generierung des Universal Messenger Newsletter-Event-Requests ist ein Fehler aufgetreten.</target>
             </trans-unit>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -69,6 +69,9 @@
             <trans-unit id="error.invalidRequest">
                 <source>The submitted request is invalid.</source>
             </trans-unit>
+            <trans-unit id="error.sendNotConfirmed">
+                <source>The newsletter was not sent. For safety, a send has to be confirmed directly in this module — it is never carried out automatically, for instance after logging in again. Please select the channel and confirm the send once more.</source>
+            </trans-unit>
             <trans-unit id="error.exceptionDuringCreate">
                 <source>An error occurred while generating the Universal Messenger newsletter event request.</source>
             </trans-unit>

--- a/Tests/Unit/Controller/TestableUniversalMessengerController.php
+++ b/Tests/Unit/Controller/TestableUniversalMessengerController.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the package netresearch/universal-messenger.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\UniversalMessenger\Tests\Unit\Controller;
+
+use Netresearch\UniversalMessenger\Controller\UniversalMessengerController;
+use Psr\Http\Message\ResponseInterface;
+use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
+use TYPO3\CMS\Extbase\Http\ForwardResponse;
+
+/**
+ * Records the flash messages instead of translating them.
+ *
+ * Translation goes through a static call that needs a bootstrapped TYPO3, which
+ * a unit test does not provide. Capturing the message key keeps the test focused
+ * on the controller decision.
+ *
+ * @author  Rico Sonntag <rico.sonntag@netresearch.de>
+ * @license Netresearch https://www.netresearch.de
+ *
+ * @see    https://www.netresearch.de
+ */
+final class TestableUniversalMessengerController extends UniversalMessengerController
+{
+    /**
+     * @var string[]
+     */
+    public array $forwardedFlashMessages = [];
+
+    protected function forwardFlashMessage(
+        string $key,
+        ContextualFeedbackSeverity $contextualFeedbackSeverity = ContextualFeedbackSeverity::ERROR,
+    ): ResponseInterface {
+        $this->forwardedFlashMessages[] = $key;
+
+        return new ForwardResponse('error');
+    }
+}

--- a/Tests/Unit/Controller/UniversalMessengerControllerTest.php
+++ b/Tests/Unit/Controller/UniversalMessengerControllerTest.php
@@ -1,0 +1,134 @@
+<?php
+
+/*
+ * This file is part of the package netresearch/universal-messenger.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\UniversalMessenger\Tests\Unit\Controller;
+
+use Netresearch\UniversalMessenger\Controller\UniversalMessengerController;
+use Netresearch\UniversalMessenger\Domain\Model\NewsletterChannel;
+use Netresearch\UniversalMessenger\Repository\EventFileRepository;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use ReflectionClass;
+use ReflectionProperty;
+use TYPO3\CMS\Extbase\Mvc\RequestInterface;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+/**
+ * Tests that sending a newsletter cannot be triggered by a replayable request.
+ *
+ * A live send is irreversible. It must never be reachable by navigation alone —
+ * neither by a bookmark or reload, nor by TYPO3 replaying a pending action after
+ * the editor logged in again.
+ *
+ * @author  Rico Sonntag <rico.sonntag@netresearch.de>
+ * @license Netresearch https://www.netresearch.de
+ *
+ * @see    https://www.netresearch.de
+ */
+#[CoversClass(UniversalMessengerController::class)]
+final class UniversalMessengerControllerTest extends UnitTestCase
+{
+    /**
+     * Every HTTP method that must not be able to trigger a send.
+     *
+     * @return array<string, array{string}>
+     */
+    public static function nonSubmittingHttpMethods(): array
+    {
+        return [
+            'GET'    => ['GET'],
+            'HEAD'   => ['HEAD'],
+            'DELETE' => ['DELETE'],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('nonSubmittingHttpMethods')]
+    public function doesNotSendTheNewsletterForANonPostRequest(string $httpMethod): void
+    {
+        $eventFileRepository = $this->createMock(EventFileRepository::class);
+
+        // The whole point: no request that can be replayed by navigation may
+        // reach the webservice.
+        $eventFileRepository
+            ->expects(self::never())
+            ->method('sendEventFile');
+
+        $subject = $this->createSubject($eventFileRepository, $httpMethod, ['send' => 'live']);
+
+        $subject->createAction(self::createStub(NewsletterChannel::class));
+
+        self::assertSame(
+            ['error.sendNotConfirmed'],
+            $subject->forwardedFlashMessages,
+            'A non-POST send request must be answered with the "not confirmed" message.',
+        );
+    }
+
+    /**
+     * Builds the controller without running its constructor.
+     *
+     * Most collaborators are final in TYPO3 v14 and cannot be doubled, and the
+     * guard under test must reject the request before any of them is touched —
+     * so only the two properties the guard and the assertion need are injected.
+     *
+     * @param array<string, string> $arguments
+     */
+    private function createSubject(
+        EventFileRepository $eventFileRepository,
+        string $httpMethod,
+        array $arguments,
+    ): TestableUniversalMessengerController {
+        /** @var TestableUniversalMessengerController $subject */
+        $subject = (new ReflectionClass(TestableUniversalMessengerController::class))
+            ->newInstanceWithoutConstructor();
+
+        $this->injectProperty($subject, 'eventFileRepository', $eventFileRepository);
+        $this->injectProperty($subject, 'request', $this->createRequest($httpMethod, $arguments));
+
+        return $subject;
+    }
+
+    /**
+     * @param array<string, string> $arguments
+     */
+    private function createRequest(string $httpMethod, array $arguments): RequestInterface
+    {
+        $request = self::createStub(RequestInterface::class);
+        $request
+            ->method('getMethod')
+            ->willReturn($httpMethod);
+        $request
+            ->method('hasArgument')
+            ->willReturnCallback(
+                static fn (string $name): bool => isset($arguments[$name]),
+            );
+        $request
+            ->method('getArgument')
+            ->willReturnCallback(
+                static fn (string $name): string => $arguments[$name] ?? '',
+            );
+
+        return $request;
+    }
+
+    /**
+     * Both properties are resolved against the controller itself: "request" is
+     * inherited and protected, "eventFileRepository" is private and declared here.
+     */
+    private function injectProperty(object $subject, string $name, object $value): void
+    {
+        $property = new ReflectionProperty(UniversalMessengerController::class, $name);
+
+        $property->setValue($subject, $value);
+    }
+}


### PR DESCRIPTION
Closes #92

## Problem

Der Versand wurde über einen einfachen GET ausgelöst, der Kanal und Versandart in der URL trug (`<f:link.action>`). Eine solche URL lässt sich als Lesezeichen speichern und neu laden — und vor allem holt TYPO3 sie nach einer erneuten Anmeldung automatisch nach.

Genau das ist auf dem v14-Teststack passiert: Klick auf „Live-Versand" bei abgelaufener Sitzung, Anmeldung, und der unumkehrbare Versand lief los, ohne noch einmal zu fragen.

```
POST /typo3/login?loginProvider=1433416747
     &redirect=netresearch_universal_messenger.UniversalMessenger_create
     &redirectParams=id%3D102%26newsletterChannel%3D100%26send%3Dlive
```

## Änderung

- `createAction` nimmt nur noch **POST** an. Alles andere wird mit einer erklärenden Meldung abgewiesen, ohne die Schnittstelle zu berühren.
- Beide Schaltflächen sind jetzt **abgesendete Formulare** statt Verweise.
- Die Live-Bestätigung bleibt erhalten und kommt **ohne eigenes JavaScript** aus: der Modal-Trigger des Kerns sendet das zugehörige Formular ab, sobald bestätigt wurde.
- Neue Meldung `error.sendNotConfirmed` in Deutsch und Englisch.

## Zwei Nebenbefunde, gleich mitbehoben

- Der Bestätigungsdialog nutzte das Attribut `bs-content`, das TYPO3 v14 nicht mehr unterstützt (der Kern schreibt dazu sogar einen Konsolenfehler). Die Warnung mit dem Kanalnamen wurde dadurch durch einen allgemeinen Standardtext ersetzt. Jetzt `content`.
- Die Live-Schaltfläche war nur optisch über eine CSS-Klasse gesperrt. Sie ist nun eine echte deaktivierte Schaltfläche.

## Tests

Neu: `Tests/Unit/Controller/UniversalMessengerControllerTest.php` — prüft für GET, HEAD und DELETE, dass die Schnittstelle **nicht** aufgerufen wird und die richtige Meldung erscheint. Testgetrieben entstanden (erst rot, dann grün).

Lokal vollständig geprüft: PHPStan fehlerfrei, Lint 55 Dateien, Stilprüfung ohne Befund, 8 Tests / 15 Zusicherungen grün.

## Hinweis zur Abnahme

Die Oberflächenänderung ist im echten Backend noch nicht durchgeklickt — das hole ich abgestimmt nach, um keine fremde Sitzung zu stören.