### PR TITLE
fix: spell out the live button data attributes individually

### DIFF
--- a/Resources/Private/Backend/Templates/UniversalMessenger/Index.html
+++ b/Resources/Private/Backend/Templates/UniversalMessenger/Index.html
@@ -73,10 +73,22 @@
                                 attribute and would otherwise show a generic text instead
                                 of the warning naming the channel.
                             -->
+                            <!--
+                                The attributes are spelled out one by one on purpose: the
+                                array form data="{...}" is an argument of Fluid ViewHelpers
+                                such as f:link.action and is not evaluated on a plain HTML
+                                element, which would leave the button without its dialog
+                                texts and without the target form.
+                            -->
                             <button
                                     type="button"
                                     class="btn btn-danger btn-lg t3js-modal-trigger"
-                                    data="{severity: 'error', title: '{f:translate(key: \'common.sendNewsletterLive\')}', content: '{f:translate(key: \'common.sendNewsletterLiveDialogContent\', arguments: {0: newsletterChannel.title})}', button-close-text: '{f:translate(key: \'common.sendNewsletterLiveButtonCancel\')}', button-ok-text: '{f:translate(key: \'common.sendNewsletterLiveButtonConfirm\')}', target-form: 'universal-messenger-send-live'}"
+                                    data-severity="error"
+                                    data-title="{f:translate(key: 'common.sendNewsletterLive')}"
+                                    data-content="{f:translate(key: 'common.sendNewsletterLiveDialogContent', arguments: {0: newsletterChannel.title})}"
+                                    data-button-close-text="{f:translate(key: 'common.sendNewsletterLiveButtonCancel')}"
+                                    data-button-ok-text="{f:translate(key: 'common.sendNewsletterLiveButtonConfirm')}"
+                                    data-target-form="universal-messenger-send-live"
                             >
                                 <f:translate key="common.sendNewsletterLive" />
                             </button>


### PR DESCRIPTION
Closes #94 — Folgefehler aus #93, beim Durchklicken im echten Backend gefunden.

## Problem

Die Modal-Angaben standen als `data="{severity: ..., content: ..., target-form: ...}"` am Knopf. Diese Feldschreibweise ist ein **Argument von Fluid-ViewHelpern** wie `f:link.action` und wird auf einem gewöhnlichen HTML-Element **nicht** ausgewertet. Seit #93 aus dem Verweis ein `<button>` wurde, landete davon nichts im Markup:

```
{"type":"button","modalTrigger":true,"targetForm":null,"hasContent":false}
```

Folgen: Der Bestätigungsdialog zeigte wieder einen allgemeinen Text statt der Warnung mit Kanalnamen, und ohne `data-target-form` hatte der Modal-Trigger des Kerns nichts zum Absenden — **der Live-Versand hätte gar nicht mehr funktioniert**. Sicherheitsseitig unkritisch (er fällt geschlossen aus), fachlich aber kaputt.

## Änderung

Attribute einzeln ausgeschrieben: `data-severity`, `data-title`, `data-content`, `data-button-close-text`, `data-button-ok-text`, `data-target-form`. Mit erklärendem Kommentar, damit die Feldschreibweise nicht zurückkehrt.

## Im echten Backend geprüft

- Knopf: `type=button`, `targetForm=universal-messenger-send-live`, `hasContent=true`, kein veraltetes `bs-content`
- Dialog nennt den Kanal: *A live delivery will be sent to channel "crmDemoChannel_Test". Are you sure you want to do this?*
- Abbrechen setzt **keine** einzige POST-Anfrage ab
- Testformular unverändert korrekt (POST, `send=test`, `type=submit`)
- keine JavaScript-Fehler, keine verbliebenen GET-Verweise auf `create`