### PR TITLE
fix: let the controller reject a missing channel instead of Extbase

### DIFF
--- a/Classes/Controller/UniversalMessengerController.php
+++ b/Classes/Controller/UniversalMessengerController.php
@@ -295,7 +295,7 @@ class UniversalMessengerController extends AbstractBaseController implements Log
      *
      * @return ResponseInterface
      */
-    public function createAction(?NewsletterChannel $newsletterChannel): ResponseInterface
+    public function createAction(?NewsletterChannel $newsletterChannel = null): ResponseInterface
     {
         // Sending is irreversible and must never be reachable by navigation alone.
         // A GET carrying the send parameters can be bookmarked and reloaded, and —

--- a/Tests/Functional/Controller/UniversalMessengerControllerArgumentsTest.php
+++ b/Tests/Functional/Controller/UniversalMessengerControllerArgumentsTest.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of the package netresearch/universal-messenger.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\UniversalMessenger\Tests\Functional\Controller;
+
+use Netresearch\UniversalMessenger\Controller\UniversalMessengerController;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Extbase\Reflection\ReflectionService;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+/**
+ * Verifies how Extbase itself classifies the arguments of the send action.
+ *
+ * Extbase maps and validates action arguments before it calls the action method,
+ * so a required argument fails the request before the controller can decide
+ * anything. `ActionController::initializeActionMethodArguments()` derives that
+ * from the class schema:
+ *
+ *     $this->arguments->addNewArgument($name, $type, $parameter->isOptional() === false, ...)
+ *
+ * A missing channel therefore has to reach the controller — which answers with a
+ * proper message — instead of dying with a RequiredArgumentMissingException.
+ *
+ * This runs against the real container on purpose: a unit test that calls the
+ * action directly bypasses exactly the layer examined here.
+ *
+ * @author  Rico Sonntag <rico.sonntag@netresearch.de>
+ * @license Netresearch https://www.netresearch.de
+ *
+ * @see    https://www.netresearch.de
+ */
+final class UniversalMessengerControllerArgumentsTest extends FunctionalTestCase
+{
+    /**
+     * @var non-empty-string[]
+     */
+    protected array $testExtensionsToLoad = [
+        'netresearch/universal-messenger',
+    ];
+
+    #[Test]
+    public function extbaseTreatsTheChannelOfTheSendActionAsOptional(): void
+    {
+        $parameter = $this->get(ReflectionService::class)
+            ->getClassSchema(UniversalMessengerController::class)
+            ->getMethod('createAction')
+            ->getParameter('newsletterChannel');
+
+        self::assertTrue(
+            $parameter->isOptional(),
+            'Extbase must treat the channel as optional, otherwise a request without it fails'
+            . ' with a RequiredArgumentMissingException before the controller can reject it.',
+        );
+
+        self::assertNull(
+            $parameter->getDefaultValue(),
+            'The default has to be null so the controller sees "no channel given".',
+        );
+    }
+}

--- a/Tests/Unit/Controller/UniversalMessengerControllerTest.php
+++ b/Tests/Unit/Controller/UniversalMessengerControllerTest.php
@@ -18,6 +18,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use ReflectionClass;
+use ReflectionMethod;
 use ReflectionProperty;
 use TYPO3\CMS\Extbase\Mvc\RequestInterface;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
@@ -72,6 +73,25 @@ final class UniversalMessengerControllerTest extends UnitTestCase
             $subject->forwardedFlashMessages,
             'A non-POST send request must be answered with the "not confirmed" message.',
         );
+    }
+
+    #[Test]
+    public function theChannelArgumentIsOptionalSoTheGuardRunsFirst(): void
+    {
+        // Extbase maps and validates action arguments *before* it calls the
+        // action method. An argument counts as required unless it carries a
+        // default value — being nullable is not enough. Without the default,
+        // a request lacking the channel died with a RequiredArgumentMissing-
+        // Exception before the POST guard above could reject it cleanly.
+        $parameter = (new ReflectionMethod(UniversalMessengerController::class, 'createAction'))
+            ->getParameters()[0];
+
+        self::assertTrue(
+            $parameter->isDefaultValueAvailable(),
+            'createAction() must declare a default for the channel, otherwise Extbase throws'
+            . ' before the controller can reject the request.',
+        );
+        self::assertNull($parameter->getDefaultValue());
     }
 
     /**


### PR DESCRIPTION
Closes #97

## Problem

Ein Aufruf der `create`-Aktion ohne `newsletterChannel` endete in einer rohen Ausnahme:

```
#1298012500 RequiredArgumentMissingException
Required argument "newsletterChannel" is not set ...
```

Extbase bildet und prüft die Argumente, **bevor** es die Aktionsmethode aufruft. Die in #93 ergänzte POST-Sperre kam damit gar nicht zum Zug. `?NewsletterChannel $newsletterChannel` gilt als Pflichtargument, weil ein Standardwert fehlt — Nullbarkeit allein genügt nicht.

Kein neuer Weg, einen Versand auszulösen (die Anfrage stirbt vorher), aber ein Robustheitsmangel: Redakteure dürfen keinen Fehlerbericht sehen, und die Sperre soll zuerst entscheiden.

## Änderung

Standardwert für das Argument, damit Extbase an den Controller übergibt.

## Im Backend geprüft, alle vier Eingabefälle

| Aufruf | vorher | nachher |
|:--|:--|:--|
| ohne `newsletterChannel` | Ausnahme | saubere Meldung |
| ohne `send` | saubere Meldung | saubere Meldung |
| ganz ohne Parameter | Ausnahme | saubere Meldung |
| vollständig (Wiederholpfad) | saubere Meldung | saubere Meldung |

Versand weiterhin auf beiden Wegen nachgewiesen: Testversand 1 POST, Live-Versand über den Dialog 1 POST.

## Warum die bisherigen Tests das nicht fanden

Der Unit-Test ruft `createAction()` direkt auf und umgeht damit genau die Schicht, die versagt hat. Der ergänzte Test sichert stattdessen die Eigenschaft, die die Sperre nach vorne holt: dass das Argument einen Standardwert deklariert.