### PR TITLE
chore(deps): drop dev-dependencies the shared package already provides

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -111,7 +111,7 @@ jobs:
     permissions: {}
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
 

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "netresearch/sdk-api-universal-messenger": "^3.0"
     },
     "require-dev": {
-        "netresearch/typo3-ci-workflows": "^1.3"
+        "netresearch/typo3-ci-workflows": "^1.4"
     },
     "suggest": {
         "typo3/cms-scheduler": "Allows you to run CLI scripts as a task within TYPO3"

--- a/composer.json
+++ b/composer.json
@@ -26,18 +26,7 @@
         "netresearch/sdk-api-universal-messenger": "^3.0"
     },
     "require-dev": {
-        "a9f/typo3-fractor": "^1.0",
-        "friendsofphp/php-cs-fixer": "^3.65",
-        "netresearch/typo3-ci-workflows": "^1.3",
-        "overtrue/phplint": "^9.5",
-        "phpat/phpat": "^0.12",
-        "phpstan/phpstan": "^2.0",
-        "phpstan/phpstan-deprecation-rules": "^2.0",
-        "phpstan/phpstan-phpunit": "^2.0",
-        "phpstan/phpstan-strict-rules": "^2.0",
-        "saschaegerer/phpstan-typo3": "^2.0 || ^3.0",
-        "ssch/typo3-rector": "^3.0",
-        "typo3/testing-framework": "^9.0"
+        "netresearch/typo3-ci-workflows": "^1.3"
     },
     "suggest": {
         "typo3/cms-scheduler": "Allows you to run CLI scripts as a task within TYPO3"
@@ -50,6 +39,7 @@
         "optimize-autoloader": true,
         "platform-check": false,
         "allow-plugins": {
+            "ergebnis/composer-normalize": true,
             "typo3/cms-composer-installers": true,
             "typo3/class-alias-loader": true,
             "php-http/discovery": true,


### PR DESCRIPTION
Part of the fleet-wide dedup pass. Companion to [netresearch/typo3-ci-workflows#158](https://github.com/netresearch/typo3-ci-workflows/pull/158), released as v1.4.0.

## What is removed

11 tools declared both here and by `netresearch/typo3-ci-workflows`, which this repo requires: `a9f/typo3-fractor`, `friendsofphp/php-cs-fixer`, `overtrue/phplint`, `phpat/phpat`, `phpstan/phpstan`, `phpstan/phpstan-deprecation-rules`, `phpstan/phpstan-phpunit`, `phpstan/phpstan-strict-rules`, `saschaegerer/phpstan-typo3`, `ssch/typo3-rector`, `typo3/testing-framework`. All 11 are required by v1.4.0 of the shared package.

Composer intersects the consumer constraint with the shared one and the narrower wins, so each duplicate is a place where a future narrowing holds an update back unnoticed. That is not hypothetical — in [t3x-contexts_wurfl](https://github.com/netresearch/t3x-contexts_wurfl/pull/44) a local `^2.0` kept `saschaegerer/phpstan-typo3` off 3.x while every other consumer had it, latest being 3.1.0.

Anything this repo declares for itself is untouched; only packages the shared package already provides are removed.

## What is changed

`netresearch/typo3-ci-workflows` is raised from `^1.3` to `^1.4`. This is a declaration fix, not a fix for a resolution that was ever broken: the branch adds `ergebnis/composer-normalize` to `config.allow-plugins` and hands the 11 tools above to the shared package, and only v1.4.0 requires `ergebnis/composer-normalize` — no v1.3.x release lists it at all. `^1.3` therefore declared less than the branch already assumes, so it is raised to say what is actually depended on.

> **Correction — a claim made in an earlier revision of this description, and in the commit message that carried it, is withdrawn.** Both stated that `^1.3` still permits v1.3.x, and that on t3x-nr-passkeys-be a `^1.2` constraint reproducibly resolved v1.3.2 without `composer-normalize`. That is wrong, and no reader should carry it forward. A caret takes the highest matching release: `^1.2` means `>=1.2.0 <2.0.0`, and with no committed lockfile it resolves to v1.4.0. The earlier v1.3.2 observation was a stale-cache artefact from the hour v1.4.0 was published. Re-measured against this repo's own `composer.json` with an empty `COMPOSER_CACHE_DIR`, substituting only the constraint:
>
> ```
> "netresearch/typo3-ci-workflows": "^1.3"
>   - Locking ergebnis/composer-normalize (2.52.0)
>   - Locking netresearch/typo3-ci-workflows (v1.4.0)
> ```
>
> The `^1.4` constraint stays, for the declaration reason above.

## What is added

`ergebnis/composer-normalize` under `config.allow-plugins` — the shared package ships it as of v1.4.0, and an unallowed Composer plugin is installed but never runs. The key sits at the top of the block; this repo's `allow-plugins` block is not alphabetically ordered (`typo3/cms-composer-installers`, `typo3/class-alias-loader`, `php-http/discovery`, `a9f/fractor-extension-installer`, …), so there is no alphabetical position to insert it at and the existing order is left untouched.

## Verification

Resolution measured before and after rather than argued from constraint algebra, with `COMPOSER_CACHE_DIR` pointed at an empty directory. `before` is `composer.json` at the merge base (`bb96c90`), `after` is this branch's:

```
$ composer update --dry-run --no-scripts --no-plugins --ignore-platform-reqs
before: 211 packages
after:  211 packages
$ diff before.pkgs after.pkgs
(empty)
```

The count is the number of `^  - Locking ` lines in the Composer output. An earlier revision of this description stated 422 packages on both sides; that number came from counting `^  - ` lines, which matches each package twice, once as `- Locking` and once as `- Installing`. Measured on the `before` run: 422 lines matching `^  - `, of which 211 are `- Locking` and 211 are `- Installing`. The corrected figure is 211 on both sides, and the conclusion — before equals after, with an identical set of locked packages — is unchanged.

The `after` run resolves the two packages this PR depends on:

```
  - Locking ergebnis/composer-normalize (2.52.0)
  - Locking netresearch/typo3-ci-workflows (v1.4.0)
```
