### PR TITLE
feat(agents): add AGENTS.md agent documentation and agent-harness verification

### DIFF
--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -1,0 +1,98 @@
+<!-- Managed by agent: keep sections and order; edit content, not structure. Last updated: 2026-08-19 -->
+
+# AGENTS.md — workflows
+
+<!-- AGENTS-GENERATED:START overview -->
+## Overview
+GitHub Actions CI for the extension. Every workflow here is a **thin caller** of a shared reusable workflow from `netresearch/typo3-ci-workflows` or `netresearch/.github` — pins, runners and step logic are maintained centrally, this repo only supplies the matrix and permissions.
+<!-- AGENTS-GENERATED:END overview -->
+
+<!-- AGENTS-GENERATED:START filemap -->
+## Key Files
+| File | Purpose |
+|------|---------|
+| `ci.yml` | Test matrix (PHP 8.2–8.5 × TYPO3 ^14.0, functional on SQLite, codecov upload) — **intentional drift**, per-extension |
+| `checks.yml` | Security/quality jobs (CodeQL, gitleaks, zizmor, fuzz, license, scorecard, dependency-review, pr-quality) + `All security checks` gate — byte-identical across t3x repos, drift-enforced |
+| `harness-verify.yml` | Agent-harness consistency check via `Build/Scripts/verify-harness.sh` |
+| `check-template-drift.yml` | Fails when shared template files drift from `netresearch/.github` |
+| `auto-merge-deps.yml` | Auto-merge for dependency PRs |
+| `labeler.yml` / `community.yml` | PR labeling; stale/lock/greetings automation |
+| `release.yml` / `republish.yml` | TER release + republish via typo3-ci-workflows reusables |
+<!-- AGENTS-GENERATED:END filemap -->
+
+<!-- AGENTS-GENERATED:START golden-samples -->
+## Workflow files
+- 9 workflows, all `uses:`-callers — no locally implemented job steps except the `gate` job in `checks.yml`
+- The extension-specific part is exactly `ci.yml`'s `with:` block; everything else should match the org template (`check-template-drift.yml` enforces this)
+<!-- AGENTS-GENERATED:END setup -->
+
+<!-- AGENTS-GENERATED:START structure -->
+## Directory structure
+```
+.github/
+  workflows/        → thin reusable-workflow callers (this directory)
+  dependabot.yml    → dependency update config
+  labeler.yml       → path-based label rules
+  template.yaml     → org template-sync manifest
+```
+No local composite actions, no repo-level PR template (the org-level template from `netresearch/.github` applies).
+<!-- AGENTS-GENERATED:END structure -->
+
+<!-- AGENTS-GENERATED:START code-style -->
+## Workflow conventions
+- **Thin callers only**: change shared behavior upstream in `netresearch/typo3-ci-workflows` / `netresearch/.github`, not here
+- **Explicit permissions** on every job; top-level `permissions: {}` or `contents: read` — never rely on defaults
+- **Every job added to `checks.yml` MUST also be added to `gate.needs`** — the ruleset requires only `All security checks`, so a job missing from the gate cannot block a merge (see the comment block in `checks.yml`)
+- Local `run:` steps (only the gate) pin third-party actions to full commit SHA
+- `ci.yml` carries the `# Per-extension test matrix (intentional-drift)` marker — keep it, the drift check reads it
+<!-- AGENTS-GENERATED:END code-style -->
+
+<!-- AGENTS-GENERATED:START patterns -->
+## Common patterns
+
+### Thin caller (the only pattern used here)
+```yaml
+jobs:
+  ci:
+    uses: netresearch/typo3-ci-workflows/.github/workflows/ci.yml@main
+    permissions:
+      contents: read
+    with:
+      php-versions: '["8.2","8.3","8.4","8.5"]'
+      typo3-versions: '["^14.0"]'
+```
+
+### Why individual check names are not required by rulesets
+PR-only jobs (`dependency-review`, `pr-quality`) never materialize on `merge_group` refs, and code-scanning checks are posted by the GitHub app, not by these jobs. Rulesets therefore require the stable gate names (`All security checks`, `ci / All CI checks`) — do not add individual job contexts to the ruleset.
+<!-- AGENTS-GENERATED:END patterns -->
+
+<!-- AGENTS-GENERATED:START security -->
+## Security & safety
+- **Never** use `secrets: inherit` — pass secrets explicitly (`ci.yml` passes only `CODECOV_TOKEN`)
+- Keep `permissions` minimal per job; the reusables document their required caller contract
+- Pin any new third-party action to a full commit SHA with a version comment
+- Scheduled weekly runs (`cron: '0 6 * * 1'`) keep CodeQL/scorecard results fresh — do not remove the `schedule` triggers
+<!-- AGENTS-GENERATED:END security -->
+
+<!-- AGENTS-GENERATED:START checklist -->
+## PR/commit checklist
+- [ ] New `checks.yml` job also listed in `gate.needs`
+- [ ] Permissions blocks minimal and explicit
+- [ ] No `secrets: inherit`; secrets passed explicitly
+- [ ] Shared files unchanged (or changed upstream first) — `Template Drift` check stays green
+- [ ] Workflow syntax valid (`actionlint` or zizmor will flag issues)
+<!-- AGENTS-GENERATED:END checklist -->
+
+<!-- AGENTS-GENERATED:START examples -->
+## Patterns to Follow
+> **Prefer looking at real code in this repo over generic examples.**
+> `ci.yml` (thin caller with matrix), `checks.yml` (gate pattern + extensive in-file rationale comments).
+<!-- AGENTS-GENERATED:END examples -->
+
+<!-- AGENTS-GENERATED:START help -->
+## When stuck
+- Shared reusables: https://github.com/netresearch/typo3-ci-workflows and https://github.com/netresearch/.github
+- GitHub Actions docs: https://docs.github.com/en/actions
+- Read the comment blocks in `checks.yml` — they document the gate/merge-queue pitfalls
+- Review root AGENTS.md for project-wide conventions
+<!-- AGENTS-GENERATED:END help -->

--- a/.github/workflows/CLAUDE.md
+++ b/.github/workflows/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/.github/workflows/harness-verify.yml
+++ b/.github/workflows/harness-verify.yml
@@ -1,0 +1,23 @@
+name: Harness Verification
+
+# Verifies agent-harness consistency (AGENTS.md line budget, dead references,
+# documented commands vs composer.json/Makefile, docs/ structure) via
+# Build/Scripts/verify-harness.sh. Thin caller of the shared script-check
+# reusable, so the checkout pin and harden-runner are maintained centrally.
+# Exit 2 means warnings only and passes; exit 1 (errors) fails the check.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  harness-verify:
+    uses: netresearch/.github/.github/workflows/script-check.yml@main
+    permissions:
+      contents: read
+    with:
+      check-cmd: bash Build/Scripts/verify-harness.sh || [ $? -eq 2 ]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,133 @@
+<!-- FOR AI AGENTS - Human readability is a side effect, not a goal -->
+<!-- Managed by agent: keep sections and order; edit content, not structure -->
+<!-- Last updated: 2026-08-19 | Last verified: 2026-08-19 -->
+
+# AGENTS.md
+
+**Precedence:** the **closest `AGENTS.md`** to the files you're changing wins. Root holds global defaults only.
+
+TYPO3 v14 backend extension (`universal_messenger`) for sending newsletters through the Universal Messenger API via `netresearch/sdk-api-universal-messenger`. Extension version: see `ext_emconf.php`.
+
+## Commands
+> Source: composer.json scripts + Makefile (verified 2026-08-19). Run `composer install` first — binaries land in `.build/bin/` (composer `bin-dir`), vendors in `.build/vendor/`.
+
+<!-- AGENTS-GENERATED:START commands -->
+| Task | Command |
+|------|---------|
+| Lint (PHP syntax) | `composer ci:test:php:lint` |
+| Static analysis (PHPStan level 8 + PHPat) | `composer ci:test:php:phpstan` (or `make phpstan`) |
+| Code style check | `composer ci:test:php:cgl` (or `make cgl`) |
+| Code style fix | `composer ci:cgl` (or `make cgl-fix`) |
+| Rector dry-run | `composer ci:test:php:rector` (or `make rector`) |
+| Fractor dry-run | `composer ci:test:php:fractor` |
+| Unit tests | `composer ci:test:php:unit` |
+| Functional tests (needs DB; CI uses SQLite) | `composer ci:test:php:functional` |
+| All checks except functional | `composer ci:test` |
+<!-- AGENTS-GENERATED:END commands -->
+
+## Response Style
+- Answer first, elaborate only if needed. No sycophantic openers ("Great question!", "Absolutely!").
+- For yes/no or status questions, lead with the answer.
+- Skip preamble. Match response length to task complexity.
+
+## Workflow
+1. **Before coding**: Read nearest `AGENTS.md` + check Golden Samples for the area you're touching
+2. **After each change**: Run the smallest relevant check (lint → phpstan → single test)
+3. **Before committing**: Run full test suite if changes affect >2 files or touch shared code
+4. **Before claiming done**: Run verification and **show output as evidence** — never say "try again", "should work now", "tested", "verified", or "all green" without pasted command output in the same turn
+
+## File Map
+<!-- AGENTS-GENERATED:START filemap -->
+```
+Classes/         → PHP code (PSR-4: Netresearch\UniversalMessenger\)
+Configuration/   → TYPO3 config: TCA, Services.yaml, Sets/, TypoScript, FlexForms, Backend module
+Resources/       → Fluid templates, XLF translations, icons, CSS
+Documentation/   → README screenshots (PNG only — no RST manual)
+Tests/           → Unit/, Functional/, Architecture/ (PHPat) suites
+Build/           → tool configs (phpstan, rector, fractor, PHPUnit XML) + Scripts/
+.github/         → CI workflows (thin callers of shared reusables)
+```
+<!-- AGENTS-GENERATED:END filemap -->
+
+Architecture: component map and dependency rules in `docs/ARCHITECTURE.md` — the rules are enforced by `Tests/Architecture/ArchitectureTest.php` (PHPat, runs inside PHPStan). Execution plans: `docs/exec-plans/`.
+
+## Golden Samples (follow these patterns)
+<!-- AGENTS-GENERATED:START golden-samples -->
+| For | Reference | Key patterns |
+|-----|-----------|--------------|
+| Backend controller | `Classes/Controller/UniversalMessengerController.php` | extends `AbstractBaseController`, ModuleTemplate, DI |
+| Service | `Classes/Service/UniversalMessengerService.php` | SDK wrapper, `SingletonInterface`, constructor DI |
+| Unit test | `Tests/Unit/Controller/UniversalMessengerControllerTest.php` | UnitTestCase, testable subclass |
+| Functional test | `Tests/Functional/Controller/UniversalMessengerControllerArgumentsTest.php` | FunctionalTestCase |
+<!-- AGENTS-GENERATED:END golden-samples -->
+
+## Heuristics (quick decisions)
+<!-- AGENTS-GENERATED:START heuristics -->
+| When | Do |
+|------|-----|
+| Adding class | Follow PSR-4 under `Classes/`; respect layer rules in `docs/ARCHITECTURE.md` |
+| Adding controller | Create in `Classes/Controller/`, register in `Configuration/Services.yaml` if backend |
+| Adding service | Create in `Classes/Service/` — services must not depend on controllers or repositories (PHPat) |
+| Running tasks | Check `make help` and `composer.json` scripts |
+| Committing | Conventional Commits + `git commit -S --signoff` (signature AND DCO both enforced) |
+| Adding dependency | Ask first - we minimize deps |
+| Unsure about pattern | Check Golden Samples above |
+<!-- AGENTS-GENERATED:END heuristics -->
+
+## Repository Settings
+<!-- AGENTS-GENERATED:START repo-settings -->
+- **Default branch:** `main`
+- **Merge strategy:** merge commits only (squash/rebase disabled)
+- **Signed commits:** required
+- **Required checks (rulesets):** `All security checks`, `CodeQL`, `DCO`, `Opengrep OSS`, `betterleaks`, `ci / All CI checks`, `scorecard`, `zizmor`
+- **Active rulesets:** require-signed-commits, t3x-baseline, t3x-pull-request
+<!-- AGENTS-GENERATED:END repo-settings -->
+
+## Boundaries
+
+### Always Do
+- Run code style + PHPStan before committing
+- Add tests for new code paths
+- Use conventional commit format: `type(scope): subject`
+- Use **atomic commits** (one logical change per commit); preserve signatures, keep bisection useful
+- **Show test output as evidence before claiming work is complete** — never say "try again", "should work now", "tested", "verified", or "all green" without pasted command output
+- Before any edit, verify `pwd` resolves inside the intended repo worktree — not `.bare/`, not `~/.claude/skills/…`, not `~/.claude/plugins/cache/…` (those are read-only caches that get clobbered on update)
+- For upstream dependency fixes: run **full** test suite, not just affected tests
+- Force-push only with `--force-with-lease`
+- Follow PSR-12 / TYPO3 CGL and PHP ^8.2 features
+
+### Ask First
+- Adding new dependencies
+- Modifying CI/CD configuration
+- Changing public API signatures
+- Repo-wide refactoring or rewrites
+- Operations that touch >3 repos (produce a dry-run plan first)
+
+### Never Do
+- Commit secrets, credentials, or sensitive data
+- Modify `.build/` or other generated files
+- Push directly to `main` — open a PR
+- Merge a PR before all review threads are resolved
+- Squash commits during merge or rebase unless the user explicitly asked
+- Edit installed skill/plugin cache paths (`~/.claude/skills/`, `~/.claude/plugins/cache/`, `**/.bare/**`) — always the source worktree
+- Reply to review comments with bare "Addressed" or "Fixed" — cite the resolving commit SHA
+- Commit a `composer.lock` — TYPO3 extension repos ship without a lockfile
+- Change `ext_tables.sql` without matching TCA changes (and vice versa)
+
+## Contributing (for AI agents)
+- **Comprehension**: Understand the problem before submitting code. Read the linked issue, understand *why* the change is needed, not just *what* to change.
+- **Context**: Every PR must explain the trade-offs considered and link to the issue it addresses. Disclose AI assistance if the project requires it.
+- **Continuity**: Respond to review feedback. Drive-by PRs without follow-up will be closed.
+
+## Scoped AGENTS.md (MUST read when working in these directories)
+<!-- AGENTS-GENERATED:START scope-index -->
+- `./Classes/AGENTS.md` — extension PHP code: controllers, services, middlewares, SDK integration
+- `./Tests/AGENTS.md` — unit, functional and architecture (PHPat) test suites
+- `./Resources/AGENTS.md` — Fluid templates, XLF translations, static assets
+- `./.github/workflows/AGENTS.md` — CI workflows: thin callers of shared reusables
+<!-- AGENTS-GENERATED:END scope-index -->
+
+> **Agents**: When you read or edit files in a listed directory, you **must** load its AGENTS.md first. It contains directory-specific conventions that override this root file.
+
+## When instructions conflict
+The nearest `AGENTS.md` wins. Explicit user prompts override files.

--- a/Build/Scripts/verify-harness.sh
+++ b/Build/Scripts/verify-harness.sh
@@ -1,0 +1,756 @@
+#!/usr/bin/env bash
+# verify-harness.sh — Portable harness consistency checker
+# Checks AGENTS.md and related files for agent harness maturity.
+# Dependencies: coreutils + git (jq optional, graceful fallback)
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Globals
+# ---------------------------------------------------------------------------
+ERRORS=0
+WARNINGS=0
+FORMAT=""
+MAX_LEVEL=3
+SINGLE_CHECK=""
+STATUS_ONLY=false
+PLATFORM="${PLATFORM:-}"
+
+# Collected output lines (for final rendering)
+declare -a OUTPUT_LINES=()
+declare -a GITHUB_LINES=()
+declare -a GITLAB_LINES=()
+
+# Per-level pass/total counters
+declare -A LEVEL_PASS=( [1]=0 [2]=0 [3]=0 )
+declare -A LEVEL_TOTAL=( [1]=0 [2]=0 [3]=0 )
+
+# Track the first failing level-1 suggestion for --status
+NEXT_STEP=""
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+usage() {
+    cat <<'USAGE'
+Usage: verify-harness.sh [OPTIONS]
+
+Verify agent harness consistency in the current repository.
+Must be run from the repo root.
+
+Options:
+  --format=text     Plain text output (default for terminals)
+  --format=github   GitHub Actions annotations (auto-detected in CI)
+  --format=gitlab   GitLab CI section annotations (auto-detected in CI)
+  --platform=P      Target platform: github, gitlab or forgejo (auto-detected
+                    from CI environment or git remote URL if not specified)
+  --level=N         Only check up to level N (1, 2, or 3; default: all)
+  --check=NAME      Run single check category: refs, commands, drift, structure
+  --status          Show current maturity level summary only
+  --help            Show this help message
+
+Exit codes:
+  0  All checks pass
+  1  Errors found (Level 1/2 failures)
+  2  Only warnings (Level 3 suggestions)
+USAGE
+    exit 0
+}
+
+# Detect output format: github if running in CI, otherwise text
+detect_format() {
+    if [[ -n "$FORMAT" ]]; then
+        return
+    fi
+    if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
+        FORMAT="github"
+    elif [[ "${GITLAB_CI:-}" == "true" ]]; then
+        FORMAT="gitlab"
+    else
+        FORMAT="text"
+    fi
+}
+
+# Detect hosting platform from CI env, git remote, or flag
+detect_platform() {
+    if [[ -n "$PLATFORM" ]]; then
+        if [[ "$PLATFORM" != "github" && "$PLATFORM" != "gitlab" && "$PLATFORM" != "forgejo" ]]; then
+            echo "Error: Unsupported PLATFORM '${PLATFORM}'. Expected 'github', 'gitlab' or 'forgejo'." >&2
+            exit 1
+        fi
+        return
+    fi
+    if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
+        # Forgejo/Gitea Actions also export GITHUB_ACTIONS=true; tell them apart
+        # by the server URL — github.com (or a *.github.* Enterprise host) is real
+        # GitHub, anything else is a self-hosted Forgejo/Gitea instance.
+        if [[ -n "${GITHUB_SERVER_URL:-}" && "${GITHUB_SERVER_URL}" != *"github."* ]]; then
+            PLATFORM="forgejo"
+        else
+            PLATFORM="github"
+        fi
+        return
+    fi
+    if [[ "${GITLAB_CI:-}" == "true" ]]; then
+        PLATFORM="gitlab"
+        return
+    fi
+    local remote_url=""
+    remote_url=$(git remote get-url origin 2>/dev/null || true)
+    if [[ "$remote_url" == *"forgejo"* || "$remote_url" == *"gitea"* ]]; then
+        PLATFORM="forgejo"
+    elif [[ "$remote_url" == *"github"* ]]; then
+        PLATFORM="github"
+    elif [[ "$remote_url" == *"gitlab"* ]]; then
+        PLATFORM="gitlab"
+    elif [[ -f ".gitlab-ci.yml" ]]; then
+        # Infer GitLab from CI config presence (e.g. self-hosted GitLab)
+        PLATFORM="gitlab"
+    elif [[ -d ".forgejo" || -d ".gitea" ]]; then
+        # Infer Forgejo/Gitea from config presence (self-hosted)
+        PLATFORM="forgejo"
+    elif [[ -d ".github" ]]; then
+        PLATFORM="github"
+    else
+        PLATFORM="github"
+    fi
+}
+
+# Record a passing check
+pass() {
+    local level="$1"
+    local msg="$2"
+    (( LEVEL_PASS[$level]++ )) || true
+    (( LEVEL_TOTAL[$level]++ )) || true
+    OUTPUT_LINES+=("  PASS|${level}|${msg}")
+}
+
+# Record a failing check (error)
+fail() {
+    local level="$1"
+    local msg="$2"
+    local file="${3-AGENTS.md}"
+    (( ERRORS++ )) || true
+    (( LEVEL_TOTAL[$level]++ )) || true
+    OUTPUT_LINES+=("  FAIL|${level}|${msg}")
+    GITHUB_LINES+=("::error file=${file}::${msg} -- required for Level ${level} harness maturity")
+    GITLAB_LINES+=("ERROR: [Level ${level}] ${msg}${file:+ (${file})}")
+    # Capture first actionable suggestion for --status
+    if [[ -z "$NEXT_STEP" ]]; then
+        NEXT_STEP="$msg"
+    fi
+}
+
+# Record a warning
+warn() {
+    local level="$1"
+    local msg="$2"
+    local file="${3-AGENTS.md}"
+    (( WARNINGS++ )) || true
+    (( LEVEL_TOTAL[$level]++ )) || true
+    OUTPUT_LINES+=("  WARN|${level}|${msg}")
+    GITHUB_LINES+=("::warning file=${file}::${msg}")
+    GITLAB_LINES+=("WARNING: [Level ${level}] ${msg}${file:+ (${file})}")
+    if [[ -z "$NEXT_STEP" ]]; then
+        NEXT_STEP="$msg"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Level 1 checks — Basic
+# ---------------------------------------------------------------------------
+check_agents_md_exists() {
+    if [[ -f "AGENTS.md" ]]; then
+        pass 1 "AGENTS.md exists"
+    else
+        fail 1 "AGENTS.md missing at repo root"
+    fi
+}
+
+check_agents_md_length() {
+    if [[ ! -f "AGENTS.md" ]]; then
+        fail 1 "AGENTS.md length check skipped (file missing)"
+        return
+    fi
+    local lines
+    lines=$(wc -l < "AGENTS.md")
+    if (( lines < 150 )); then
+        pass 1 "AGENTS.md is index-format (${lines} lines)"
+    else
+        fail 1 "AGENTS.md is ${lines} lines (should be under 150)"
+    fi
+}
+
+check_agents_md_commands() {
+    if [[ ! -f "AGENTS.md" ]]; then
+        fail 1 "Commands section check skipped (AGENTS.md missing)"
+        return
+    fi
+    if grep -qi '^## *\(available \)\?commands' "AGENTS.md"; then
+        pass 1 "Commands section found"
+    else
+        fail 1 "AGENTS.md missing ## Commands section"
+    fi
+}
+
+check_docs_exists() {
+    if [[ -d "docs" ]]; then
+        pass 1 "docs/ directory exists"
+    else
+        fail 1 "docs/ directory missing" ""
+    fi
+}
+
+run_level1() {
+    check_agents_md_exists
+    check_agents_md_length
+    check_agents_md_commands
+    check_docs_exists
+}
+
+# ---------------------------------------------------------------------------
+# Level 2 checks — Verified
+# ---------------------------------------------------------------------------
+
+# Check that all local file references in AGENTS.md resolve
+check_refs() {
+    if [[ ! -f "AGENTS.md" ]]; then
+        fail 2 "Reference check skipped (AGENTS.md missing)"
+        return
+    fi
+    local has_broken=false
+    # Extract markdown links: [text](path) — skip http(s):// and #anchors
+    while IFS= read -r ref; do
+        # Strip anchor (#...) and query string (?...)
+        local clean
+        clean="${ref%%#*}"
+        clean="${clean%%\?*}"
+        # Skip empty after stripping
+        [[ -z "$clean" ]] && continue
+        # Skip URLs
+        [[ "$clean" =~ ^https?:// ]] && continue
+        # Check if file/dir exists
+        if [[ ! -e "$clean" ]]; then
+            warn 2 "Broken reference in AGENTS.md: ${ref} -> ${clean} not found"
+            has_broken=true
+        fi
+    done < <(grep -oP '\]\(\K[^)]+' "AGENTS.md" 2>/dev/null || true)
+
+    if [[ "$has_broken" == false ]]; then
+        pass 2 "All references resolve"
+    fi
+}
+
+# Check that documented commands have matching targets/scripts
+check_commands() {
+    if [[ ! -f "AGENTS.md" ]]; then
+        fail 2 "Command check skipped (AGENTS.md missing)"
+        return
+    fi
+
+    local found_any=false
+
+    # -- Makefile targets --
+    if [[ -f "Makefile" ]]; then
+        found_any=true
+        local has_make_issue=false
+        while IFS= read -r target; do
+            # Check if Makefile defines this target (pattern: "target:" at start of line)
+            if ! grep -qE "^${target}[[:space:]]*:" "Makefile"; then
+                warn 2 "make ${target}: no matching Makefile target (warning)"
+                has_make_issue=true
+            fi
+        done < <(grep -oP '`make\s+\K[a-zA-Z0-9_-]+' "AGENTS.md" 2>/dev/null || true)
+        if [[ "$has_make_issue" == false ]]; then
+            local make_count
+            make_count=$(grep -oP '`make\s+\K[a-zA-Z0-9_-]+' "AGENTS.md" 2>/dev/null | wc -l || true)
+            if [[ "$make_count" -gt 0 ]]; then
+                pass 2 "All make targets verified (${make_count} targets)"
+            fi
+        fi
+    fi
+
+    # -- composer.json scripts --
+    if [[ -f "composer.json" ]]; then
+        found_any=true
+        local has_composer_issue=false
+        # Built-in composer commands that are NOT user-defined scripts
+        local composer_builtins="install|update|require|remove|dump-autoload|dumpautoload|clear-cache|clearcache|config|create-project|exec|global|init|outdated|prohibits|why|why-not|search|self-update|selfupdate|show|status|validate|archive|browse|check-platform-reqs|diagnose|fund|licenses|run-script|suggests|upgrade"
+        while IFS= read -r script; do
+            # Skip built-in composer commands
+            if echo "$script" | grep -qE "^(${composer_builtins})$"; then
+                continue
+            fi
+            # Look for the script name in composer.json's scripts section
+            # Using grep since jq is optional
+            if ! grep -qE "\"${script}\"" "composer.json"; then
+                warn 2 "composer ${script}: no matching composer.json script (warning)"
+                has_composer_issue=true
+            fi
+        done < <(grep -oP '`composer\s+\K[a-zA-Z0-9:_-]+' "AGENTS.md" 2>/dev/null || true)
+        if [[ "$has_composer_issue" == false ]]; then
+            local composer_count
+            composer_count=$(grep -oP '`composer\s+\K[a-zA-Z0-9:_-]+' "AGENTS.md" 2>/dev/null | wc -l || true)
+            if [[ "$composer_count" -gt 0 ]]; then
+                pass 2 "All composer scripts verified (${composer_count} scripts)"
+            fi
+        fi
+    fi
+
+    # -- package.json scripts --
+    if [[ -f "package.json" ]]; then
+        found_any=true
+        local has_npm_issue=false
+        while IFS= read -r script; do
+            if ! grep -qE "\"${script}\"" "package.json"; then
+                warn 2 "npm run ${script}: no matching package.json script (warning)"
+                has_npm_issue=true
+            fi
+        done < <(grep -oP '`npm run\s+\K[a-zA-Z0-9:_-]+' "AGENTS.md" 2>/dev/null || true)
+        if [[ "$has_npm_issue" == false ]]; then
+            local npm_count
+            npm_count=$(grep -oP '`npm run\s+\K[a-zA-Z0-9:_-]+' "AGENTS.md" 2>/dev/null | wc -l || true)
+            if [[ "$npm_count" -gt 0 ]]; then
+                pass 2 "All npm scripts verified (${npm_count} scripts)"
+            fi
+        fi
+    fi
+
+    if [[ "$found_any" == false ]]; then
+        pass 2 "No build system files found to check commands against"
+    fi
+}
+
+check_architecture_doc() {
+    if [[ -f "docs/ARCHITECTURE.md" ]]; then
+        pass 2 "docs/ARCHITECTURE.md exists"
+    else
+        fail 2 "docs/ARCHITECTURE.md missing" ""
+    fi
+}
+
+check_ci_workflow() {
+    if [[ "$PLATFORM" == "gitlab" ]]; then
+        if [[ -f ".gitlab-ci.yml" ]]; then
+            # Search root file and all include:local files for harness job
+            local found_harness=false
+            if grep -qE "harness-verify|verify-harness" ".gitlab-ci.yml"; then
+                found_harness=true
+            else
+                # Check files referenced via include:local (supports globs).
+                # Portable parser using sed/awk — handles common GitLab CI forms:
+                #   include: { local: 'path' }
+                #   include:
+                #     - local: 'path'
+                #   include:
+                #     - local:
+                #         - path1
+                #         - path2
+                # Skips PCRE (-P) and lookaround for BSD/macOS grep portability.
+                while IFS= read -r inc_pattern; do
+                    [[ -z "$inc_pattern" ]] && continue
+                    # shellcheck disable=SC2086
+                    for inc_file in $inc_pattern; do
+                        if [[ -f "$inc_file" ]] && grep -qE "harness-verify|verify-harness" "$inc_file"; then
+                            found_harness=true
+                            break 2
+                        fi
+                    done
+                done < <(awk '
+                    /^[[:space:]]*-?[[:space:]]*local:[[:space:]]*\[/ {
+                        # inline list form: local: [a.yml, b.yml]
+                        s=$0; sub(/.*local:[[:space:]]*\[/,"",s); sub(/\].*/,"",s);
+                        n=split(s, a, /[[:space:]]*,[[:space:]]*/);
+                        for (i=1;i<=n;i++) print a[i]; next
+                    }
+                    /^[[:space:]]*-?[[:space:]]*local:[[:space:]]*[^[:space:]\[]/ {
+                        # scalar form: local: path or - local: path
+                        s=$0; sub(/.*local:[[:space:]]*/,"",s); print s; next
+                    }
+                ' ".gitlab-ci.yml" 2>/dev/null | tr -d "'\"" || true)
+            fi
+            if [[ "$found_harness" == true ]]; then
+                pass 2 "CI harness job found in GitLab CI config"
+            else
+                warn 2 "CI config exists (.gitlab-ci.yml) but no harness-verify job found"
+            fi
+        else
+            fail 2 "CI harness workflow missing -- create .gitlab-ci.yml with a harness-verify job" ""
+        fi
+    elif [[ "$PLATFORM" == "forgejo" ]]; then
+        if [[ -f ".forgejo/workflows/harness-verify.yml" || -f ".gitea/workflows/harness-verify.yml" ]]; then
+            pass 2 "CI harness workflow exists"
+        else
+            fail 2 "CI harness workflow missing -- create .forgejo/workflows/harness-verify.yml" ""
+        fi
+    else
+        if [[ -f ".github/workflows/harness-verify.yml" ]]; then
+            pass 2 "CI harness workflow exists"
+        else
+            fail 2 "CI harness workflow missing -- create .github/workflows/harness-verify.yml" ""
+        fi
+    fi
+}
+
+run_level2() {
+    check_refs
+    check_commands
+    check_architecture_doc
+    check_ci_workflow
+}
+
+# ---------------------------------------------------------------------------
+# Level 3 checks — Enforced
+# ---------------------------------------------------------------------------
+
+check_hooks_autosetup() {
+    local found=false
+    local via=""
+
+    # Check .envrc for hooksPath
+    if [[ -f ".envrc" ]] && grep -q "hooksPath" ".envrc"; then
+        found=true
+        via=".envrc"
+    fi
+
+    # Check for Husky
+    if [[ -d ".husky" ]]; then
+        found=true
+        via=".husky"
+    fi
+
+    # Check composer.json for post-install-cmd with hooks
+    if [[ -f "composer.json" ]] && grep -q "post-install-cmd" "composer.json"; then
+        if grep -q "hook" "composer.json"; then
+            found=true
+            via="composer.json post-install-cmd"
+        fi
+    fi
+
+    if [[ "$found" == true ]]; then
+        pass 3 "Git hooks auto-setup via ${via}"
+    else
+        warn 3 "No git hooks auto-setup detected (.envrc hooksPath, .husky/, or composer.json post-install-cmd)"
+    fi
+}
+
+check_pr_template() {
+    if [[ "$PLATFORM" == "forgejo" ]]; then
+        # Forgejo/Gitea honour PR templates under .forgejo/, .gitea/ or .github/
+        local f
+        for f in .forgejo/pull_request_template.md .gitea/pull_request_template.md \
+                 .forgejo/PULL_REQUEST_TEMPLATE.md .gitea/PULL_REQUEST_TEMPLATE.md \
+                 .github/pull_request_template.md; do
+            if [[ -f "$f" ]]; then
+                pass 3 "PR template exists ($f)"
+                return
+            fi
+        done
+        warn 3 "PR template missing (create .forgejo/pull_request_template.md)"
+        return
+    fi
+    if [[ "$PLATFORM" == "gitlab" ]]; then
+        if [[ -d ".gitlab/merge_request_templates" ]]; then
+            local tmpl_count
+            tmpl_count=$(find .gitlab/merge_request_templates -maxdepth 1 -type f -name '*.md' 2>/dev/null | wc -l)
+            if (( tmpl_count > 0 )); then
+                pass 3 "MR template exists (.gitlab/merge_request_templates/, ${tmpl_count} template(s))"
+                return
+            fi
+        fi
+        warn 3 "MR template missing (create .gitlab/merge_request_templates/Default.md)"
+    else
+        if [[ -f ".github/pull_request_template.md" ]]; then
+            pass 3 "PR template exists (repo-level)"
+            return
+        fi
+        if [[ -d ".github/PULL_REQUEST_TEMPLATE" ]]; then
+            pass 3 "PR template exists (directory form)"
+            return
+        fi
+        local org=""
+        org=$(git remote get-url origin 2>/dev/null | sed -n 's|.*github\.com[:/]\([^/]*\)/.*|\1|p')
+        if [[ -n "$org" ]]; then
+            local api_result=""
+            api_result=$(gh api "repos/${org}/.github/contents/pull_request_template.md" --jq '.name' 2>/dev/null || true)
+            if [[ "$api_result" == "pull_request_template.md" ]]; then
+                pass 3 "PR template exists (org-level via ${org}/.github)"
+                return
+            fi
+        fi
+        warn 3 "PR template missing (.github/pull_request_template.md or org-level)"
+    fi
+}
+
+check_drift() {
+    # Skip if git is not available
+    if ! command -v git &>/dev/null; then
+        pass 3 "Drift check skipped (git not available)"
+        return
+    fi
+
+    # Skip if not in a git repo
+    if ! git rev-parse --git-dir &>/dev/null 2>&1; then
+        pass 3 "Drift check skipped (not a git repository)"
+        return
+    fi
+
+    # Skip if no parent commit (initial commit)
+    if ! git rev-parse HEAD~1 &>/dev/null 2>&1; then
+        pass 3 "Drift check skipped (no parent commit)"
+        return
+    fi
+
+    # Check if build/CI files changed in last commit
+    local build_files_changed=false
+    local agents_changed=false
+
+    while IFS= read -r changed_file; do
+        case "$changed_file" in
+            Makefile|composer.json|package.json|.github/workflows/*|.gitlab-ci.yml|.forgejo/workflows/*|.gitea/workflows/*)
+                build_files_changed=true
+                ;;
+            AGENTS.md)
+                agents_changed=true
+                ;;
+        esac
+    done < <(git diff --name-only HEAD~1 HEAD 2>/dev/null || true)
+
+    if [[ "$build_files_changed" == true && "$agents_changed" == false ]]; then
+        warn 3 "Potential drift: build/CI files changed in last commit but AGENTS.md was not updated"
+    else
+        pass 3 "No drift detected"
+    fi
+}
+
+run_level3() {
+    check_hooks_autosetup
+    check_pr_template
+    check_drift
+}
+
+# ---------------------------------------------------------------------------
+# Output rendering
+# ---------------------------------------------------------------------------
+
+render_text() {
+    echo "Agent Harness Verification"
+    echo "=========================="
+    echo ""
+
+    local current_level=0
+    local level_names=( [1]="Basic" [2]="Verified" [3]="Enforced" )
+
+    for line in "${OUTPUT_LINES[@]}"; do
+        local kind level msg
+        kind="${line%%|*}"
+        local rest="${line#*|}"
+        level="${rest%%|*}"
+        msg="${rest#*|}"
+        kind="${kind#"${kind%%[![:space:]]*}"}" # trim leading whitespace
+
+        # Print level header when level changes
+        if (( level != current_level )); then
+            if (( current_level != 0 )); then
+                echo ""
+            fi
+            echo "Level ${level} -- ${level_names[$level]}"
+            current_level=$level
+        fi
+
+        case "$kind" in
+            PASS) echo "  ✓ ${msg}" ;;
+            FAIL) echo "  ✗ ${msg}" ;;
+            WARN) echo "  ! ${msg}" ;;
+        esac
+    done
+
+    echo ""
+
+    # Summary line
+    local maturity_level=0
+    for lvl in 1 2 3; do
+        if (( ${LEVEL_TOTAL[$lvl]} > 0 && ${LEVEL_PASS[$lvl]} == ${LEVEL_TOTAL[$lvl]} )); then
+            maturity_level=$lvl
+        else
+            break
+        fi
+    done
+
+    local status="COMPLETE"
+    if (( maturity_level == 0 )); then
+        if (( LEVEL_TOTAL[1] > 0 && LEVEL_PASS[1] > 0 )); then
+            status="PARTIAL"
+        else
+            status="NONE"
+        fi
+        maturity_level=1
+    elif (( maturity_level < 3 )); then
+        # Check if next level is partially done
+        local next_lvl=$(( maturity_level + 1 ))
+        if (( ${LEVEL_TOTAL[$next_lvl]} > 0 && ${LEVEL_PASS[$next_lvl]} < ${LEVEL_TOTAL[$next_lvl]} )); then
+            status="PARTIAL"
+        fi
+    fi
+
+    echo "Summary: Level ${maturity_level} ${status} | ${ERRORS} error(s), ${WARNINGS} warning(s)"
+}
+
+render_github() {
+    if (( ${#GITHUB_LINES[@]} > 0 )); then
+        for line in "${GITHUB_LINES[@]}"; do
+            echo "$line"
+        done
+    fi
+}
+
+render_gitlab() {
+    local ts
+    ts=$(date +%s)
+    echo -e "\e[0Ksection_start:${ts}:harness_verify[collapsed=false]\r\e[0KAgent Harness Verification"
+    if (( ${#GITLAB_LINES[@]} > 0 )); then
+        for line in "${GITLAB_LINES[@]}"; do
+            echo "$line"
+        done
+    fi
+    echo ""
+    echo "Summary: ${ERRORS} error(s), ${WARNINGS} warning(s)"
+    echo -e "\e[0Ksection_end:${ts}:harness_verify\r\e[0K"
+}
+
+render_status() {
+    # Determine highest fully-passing level
+    local maturity_level=0
+    local level_names=( [1]="Basic" [2]="Verified" [3]="Enforced" )
+
+    for lvl in 1 2 3; do
+        if (( ${LEVEL_TOTAL[$lvl]} > 0 && ${LEVEL_PASS[$lvl]} == ${LEVEL_TOTAL[$lvl]} )); then
+            maturity_level=$lvl
+        else
+            break
+        fi
+    done
+
+    local status
+    if (( maturity_level == 0 )); then
+        if (( LEVEL_TOTAL[1] > 0 && LEVEL_PASS[1] > 0 )); then
+            status="PARTIAL"
+        else
+            status="NONE"
+        fi
+        # Display as Level 1 when no level is fully complete
+        local display_level=1
+        echo "Harness Maturity: Level ${display_level} (${level_names[$display_level]}) -- ${status}"
+    else
+        echo "Harness Maturity: Level ${maturity_level} (${level_names[$maturity_level]}) -- COMPLETE"
+    fi
+
+    for lvl in 1 2 3; do
+        if (( ${LEVEL_TOTAL[$lvl]} > 0 )); then
+            echo "  Level ${lvl}: ${LEVEL_PASS[$lvl]}/${LEVEL_TOTAL[$lvl]} checks pass"
+        fi
+    done
+
+    if [[ -n "$NEXT_STEP" ]]; then
+        echo "Next step: ${NEXT_STEP}"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+main() {
+    # Parse arguments
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --format=*)
+                FORMAT="${1#--format=}"
+                ;;
+            --platform=*)
+                PLATFORM="${1#--platform=}"
+                if [[ ! "$PLATFORM" =~ ^(github|gitlab|forgejo)$ ]]; then
+                    echo "Error: --platform must be 'github', 'gitlab' or 'forgejo'" >&2
+                    exit 1
+                fi
+                ;;
+            --level=*)
+                MAX_LEVEL="${1#--level=}"
+                if [[ ! "$MAX_LEVEL" =~ ^[123]$ ]]; then
+                    echo "Error: --level must be 1, 2, or 3" >&2
+                    exit 1
+                fi
+                ;;
+            --check=*)
+                SINGLE_CHECK="${1#--check=}"
+                ;;
+            --status)
+                STATUS_ONLY=true
+                ;;
+            --help|-h)
+                usage
+                ;;
+            *)
+                echo "Unknown option: $1" >&2
+                echo "Run with --help for usage info" >&2
+                exit 1
+                ;;
+        esac
+        shift
+    done
+
+    detect_format
+    detect_platform
+
+    # Run single check category if requested
+    if [[ -n "$SINGLE_CHECK" ]]; then
+        case "$SINGLE_CHECK" in
+            refs)       check_refs ;;
+            commands)   check_commands ;;
+            drift)      check_drift ;;
+            structure)
+                check_agents_md_exists
+                check_docs_exists
+                check_architecture_doc
+                check_ci_workflow
+                check_pr_template
+                ;;
+            *)
+                echo "Unknown check: ${SINGLE_CHECK}" >&2
+                echo "Valid checks: refs, commands, drift, structure" >&2
+                exit 1
+                ;;
+        esac
+    else
+        # Run all checks up to MAX_LEVEL
+        if (( MAX_LEVEL >= 1 )); then
+            run_level1
+        fi
+        if (( MAX_LEVEL >= 2 )); then
+            run_level2
+        fi
+        if (( MAX_LEVEL >= 3 )); then
+            run_level3
+        fi
+    fi
+
+    # Render output
+    if [[ "$STATUS_ONLY" == true ]]; then
+        render_status
+    elif [[ "$FORMAT" == "github" ]]; then
+        render_github
+    elif [[ "$FORMAT" == "gitlab" ]]; then
+        render_gitlab
+    else
+        render_text
+    fi
+
+    # Exit code
+    if (( ERRORS > 0 )); then
+        exit 1
+    elif (( WARNINGS > 0 )); then
+        exit 2
+    else
+        exit 0
+    fi
+}
+
+main "$@"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/Classes/AGENTS.md
+++ b/Classes/AGENTS.md
@@ -1,0 +1,127 @@
+<!-- Managed by agent: keep sections and order; edit content, not structure. Last updated: 2026-08-19 -->
+
+# AGENTS.md — Classes
+
+<!-- AGENTS-GENERATED:START overview -->
+## Overview
+PHP code of the `universal_messenger` TYPO3 v14 extension: a backend module (Extbase controller) for sending newsletters through the Universal Messenger API, plus frontend middlewares, an import CLI command and backend event listeners. The API is accessed exclusively through `netresearch/sdk-api-universal-messenger` (`Netresearch\Sdk\UniversalMessenger\*`).
+<!-- AGENTS-GENERATED:END overview -->
+
+<!-- AGENTS-GENERATED:START filemap -->
+## Key Files
+| File | Purpose |
+|------|---------|
+| `Controller/UniversalMessengerController.php` | Backend module controller (newsletter selection/sending) |
+| `Controller/NewsletterPreviewController.php` | Extbase frontend plugin rendering the newsletter preview |
+| `Service/UniversalMessengerService.php` | Wraps the SDK client; configured from extension settings |
+| `Service/NewsletterRenderService.php` | Renders newsletter pages to HTML via HTTP requests |
+| `Repository/NewsletterRepository.php` | Infrastructure repository talking to the UM API (via services) |
+| `Domain/Repository/NewsletterChannelRepository.php` | Extbase repository for imported channels (DB) |
+| `Command/ImportCommand.php` | CLI `universal-messenger:newsletter-channels:import` (schedulable) |
+| `Middleware/InlineCssMiddleware.php` + `Middleware/DecodeCurlyBracesMiddleware.php` | Frontend PSR-15 middlewares post-processing newsletter HTML (see `Configuration/RequestMiddlewares.php`) |
+<!-- AGENTS-GENERATED:END filemap -->
+
+<!-- AGENTS-GENERATED:START golden-samples -->
+## Golden Samples (follow these patterns)
+| Pattern | Reference |
+|---------|-----------|
+| Backend controller | `Controller/UniversalMessengerController.php` |
+| Service (SDK wrapper, singleton) | `Service/UniversalMessengerService.php` |
+| Event listener (tagged in Services.yaml) | `Backend/EventListener/PageContentPreviewRenderingEventListener.php` |
+| ViewHelper | `ViewHelpers/Format/PlaceholderViewHelper.php` |
+<!-- AGENTS-GENERATED:END golden-samples -->
+
+<!-- AGENTS-GENERATED:START setup -->
+## Setup & environment
+- Install dev tools: `composer install` (binaries in `.build/bin/`, vendors in `.build/vendor/`)
+- PHP: ^8.2 · TYPO3: ^14.0 (core, backend, frontend, extbase, fluid, lowlevel)
+- Services are autowired/autoconfigured via `Configuration/Services.yaml`; `Domain/Model/*` is excluded from DI
+<!-- AGENTS-GENERATED:END setup -->
+
+<!-- AGENTS-GENERATED:START structure -->
+## Directory structure
+```
+Classes/
+  Controller/      → Backend module + preview plugin controllers
+  Service/         → Business logic (SDK access, newsletter rendering)
+  Repository/      → Infrastructure repositories (UM API-backed, extend AbstractRepository)
+  Domain/          → Model/ (NewsletterChannel) + Repository/ (Extbase, DB-backed)
+  Middleware/      → Frontend PSR-15 middlewares
+  Command/         → Symfony console commands
+  Backend/         → EventListener/ for backend events
+  DataProcessing/  → ControlStructureProcessor (FlexForm data processor)
+  ViewHelpers/     → Fluid ViewHelpers (Condition/, Format/, Html/)
+```
+Layer rules (enforced by PHPat, see `../docs/ARCHITECTURE.md`): nothing depends on controllers; services must not depend on repositories; `Domain/` depends on no other layer.
+<!-- AGENTS-GENERATED:END structure -->
+
+<!-- AGENTS-GENERATED:START commands -->
+## Build & tests
+| Task | Command |
+|------|---------|
+| Lint | `composer ci:test:php:lint` |
+| Code style check / fix | `composer ci:test:php:cgl` / `composer ci:cgl` |
+| PHPStan (level 8 + PHPat) | `composer ci:test:php:phpstan` |
+| Rector / Fractor dry-run | `composer ci:test:php:rector` / `composer ci:test:php:fractor` |
+| Unit / Functional tests | `composer ci:test:php:unit` / `composer ci:test:php:functional` |
+| Everything except functional | `composer ci:test` |
+<!-- AGENTS-GENERATED:END commands -->
+
+<!-- AGENTS-GENERATED:START code-style -->
+## Code style & conventions
+- **PSR-12** + TYPO3 CGL, enforced by `php-cs-fixer` (`Build/.php-cs-fixer.dist.php`)
+- Strict types: `declare(strict_types=1);` in all PHP files; license header block on top
+- Namespace: `Netresearch\UniversalMessenger\` (PSR-4 from `Classes/`)
+- Constructor dependency injection via `Configuration/Services.yaml` autowiring; `GeneralUtility::makeInstance()` only where DI is unavailable (e.g. inside commands at runtime)
+- Services implement `SingletonInterface` where stateless
+- New PHPStan findings: fix them — regenerate the baseline (`composer ci:test:php:phpstan:baseline`) only for pre-existing debt
+
+### Naming conventions
+| Type | Convention | Example |
+|------|------------|---------|
+| Extension key | `lowercase_underscore` | `universal_messenger` |
+| Composer name | `vendor/ext-key` | `netresearch/universal-messenger` |
+| Namespace | `Vendor\ExtKey\` | `Netresearch\UniversalMessenger\` |
+| Controller | `*Controller` | `NewsletterPreviewController` |
+| Repository | `*Repository` | `NewsletterChannelRepository` |
+| ViewHelper | `*ViewHelper` | `PlaceholderViewHelper` |
+<!-- AGENTS-GENERATED:END code-style -->
+
+<!-- AGENTS-GENERATED:START security -->
+## Security & safety
+- API credentials (base URL, key, secret) come from the extension configuration (`ext_conf_template.txt`) — never hard-code or log them
+- **Escape output** in Fluid: `{variable}` auto-escapes; `<f:format.raw>` only for content that is sanitized upstream
+- Use QueryBuilder/Extbase repositories — never raw SQL
+- Backend access is permission-gated (`be_groups`/`be_users` TCA overrides define newsletter channel access); keep access checks when touching the module
+- Middlewares post-process frontend responses — validate assumptions about content type before rewriting the body
+<!-- AGENTS-GENERATED:END security -->
+
+<!-- AGENTS-GENERATED:START checklist -->
+## PR/commit checklist
+- [ ] `composer ci:test` passes (lint, phpstan, rector, fractor, unit, cgl)
+- [ ] Functional tests pass if controllers/TCA/DB code changed: `composer ci:test:php:functional`
+- [ ] No new PHPat layer violations (part of the phpstan run)
+- [ ] TCA changes have matching SQL in `ext_tables.sql`
+- [ ] New services registered/autowirable via `Configuration/Services.yaml`
+<!-- AGENTS-GENERATED:END checklist -->
+
+<!-- AGENTS-GENERATED:START examples -->
+## Patterns to Follow
+> **Prefer looking at real code in this repo over generic examples.**
+> See **Golden Samples** section above for files that demonstrate correct patterns.
+<!-- AGENTS-GENERATED:END examples -->
+
+<!-- AGENTS-GENERATED:START help -->
+## When stuck
+- TYPO3 Core API: https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/
+- TCA Reference: https://docs.typo3.org/m/typo3/reference-tca/main/en-us/
+- SDK source: `.build/vendor/netresearch/sdk-api-universal-messenger/` (after `composer install`)
+- Check `../docs/ARCHITECTURE.md` for the component map and layer rules
+- Review root AGENTS.md for project-wide conventions
+<!-- AGENTS-GENERATED:END help -->
+
+<!-- AGENTS-GENERATED:START skill-reference -->
+## Skill Reference
+> For TYPO3 extension standards, TER compliance, and conformance checks:
+> **Invoke skill:** `typo3-conformance`
+<!-- AGENTS-GENERATED:END skill-reference -->

--- a/Classes/CLAUDE.md
+++ b/Classes/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/Resources/AGENTS.md
+++ b/Resources/AGENTS.md
@@ -1,0 +1,65 @@
+<!-- Managed by agent: keep sections and order; edit content, not structure. Last updated: 2026-08-19 -->
+
+# AGENTS.md — Resources
+
+<!-- AGENTS-GENERATED:START overview -->
+## Overview
+Fluid templates, XLIFF translations and static assets of the `universal_messenger` extension: backend module views, newsletter content-element/page templates and the backend module stylesheet.
+<!-- AGENTS-GENERATED:END overview -->
+
+<!-- AGENTS-GENERATED:START filemap -->
+## Setup & environment
+```
+Private/Language/                → XLIFF translations (locallang*.xlf, Backend.xlf + de.* counterparts)
+Private/Backend/                 → Backend module Layouts/ and Templates/
+Private/Templates/               → Frontend Fluid: Backend/, ContentElements/, Page/, ViewHelpers/
+Private/Layouts/                 → Shared Fluid layouts
+Private/FluidStyledMailContent/  → Mail-optimized content element templates
+Public/Icons/                    → Extension and module icons
+Public/Css/                      → Module.css (registered in ext_localconf.php as BE stylesheet)
+```
+<!-- AGENTS-GENERATED:END setup -->
+
+<!-- AGENTS-GENERATED:START types -->
+## Common patterns
+- Newsletter HTML is rendered from `Private/Templates/` + `Private/FluidStyledMailContent/` and then post-processed by the frontend middlewares (`Classes/Middleware/`) — CSS inlining happens there, not in the templates
+- Custom ViewHelpers used in these templates live in `Classes/ViewHelpers/` (`Condition/`, `Format/`, `Html/`)
+- Every user-facing string goes through XLIFF: default-language file plus `de.`-prefixed German counterpart in `Private/Language/`
+<!-- AGENTS-GENERATED:END types -->
+
+<!-- AGENTS-GENERATED:START code-style -->
+## Code style & conventions
+- Fluid: UpperCamelCase template names matching controller actions; keep logic in ViewHelpers/controllers, not in templates
+- XLIFF: keep `trans-unit` IDs stable — they are referenced from PHP and Fluid; add new units to the default file first, then translate in the `de.` file
+- Mail templates must stay email-client-safe: table-based layout helpers from `Classes/ViewHelpers/Html/` (Row/Column/Container/Spacer), no external CSS assumptions
+- CSS: `Public/Css/Module.css` styles the backend module only
+<!-- AGENTS-GENERATED:END code-style -->
+
+<!-- AGENTS-GENERATED:START security -->
+## Security & safety
+- Never store secrets or API credentials in templates, translation files or CSS
+- Fluid `{variable}` auto-escapes — use `<f:format.raw>` only for content sanitized upstream (the middleware pipeline expects escaped template output)
+- Universal Messenger placeholders are curly-brace-wrapped; `DecodeCurlyBracesMiddleware` re-decodes braces that the CSS-inlining DOM step encoded in URLs — do not work around encoding issues inside templates
+<!-- AGENTS-GENERATED:END security -->
+
+<!-- AGENTS-GENERATED:START checklist -->
+## PR/commit checklist
+- [ ] New strings exist in the default XLIFF file and the `de.` counterpart
+- [ ] Template changes verified in the rendered newsletter preview, not only in the backend module
+- [ ] No secrets or environment-specific URLs in resources
+- [ ] XLIFF/XML files are well-formed (`composer ci:test:php:lint` does not cover XML — validate manually)
+<!-- AGENTS-GENERATED:END checklist -->
+
+<!-- AGENTS-GENERATED:START examples -->
+## Patterns to Follow
+> **Prefer looking at real code in this repo over generic examples.**
+> `Private/Language/locallang.xlf` + `Private/Language/de.locallang.xlf` (translation pairing), `Private/FluidStyledMailContent/` (mail-safe markup).
+<!-- AGENTS-GENERATED:END examples -->
+
+<!-- AGENTS-GENERATED:START help -->
+## When stuck
+- Fluid reference: https://docs.typo3.org/other/typo3fluid/fluid/main/en-us/
+- XLIFF in TYPO3: https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ApiOverview/Localization/Index.html
+- Check how templates are consumed in `Classes/Service/NewsletterRenderService.php` and the middlewares
+- Review root AGENTS.md for project-wide conventions
+<!-- AGENTS-GENERATED:END help -->

--- a/Resources/CLAUDE.md
+++ b/Resources/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/Tests/AGENTS.md
+++ b/Tests/AGENTS.md
@@ -1,0 +1,98 @@
+<!-- Managed by agent: keep sections and order; edit content, not structure. Last updated: 2026-08-19 -->
+
+# AGENTS.md — Tests
+
+<!-- AGENTS-GENERATED:START overview -->
+## Overview
+Test suites of the `universal_messenger` extension: PHPUnit unit and functional tests plus PHPat architecture rules. **Use the `typo3-testing` skill** for comprehensive guidance.
+<!-- AGENTS-GENERATED:END overview -->
+
+<!-- AGENTS-GENERATED:START setup -->
+## Setup
+- `composer install` first — PHPUnit and the TYPO3 testing framework land in `.build/` (composer `vendor-dir`/`bin-dir`)
+- PHPUnit configs live in `Build/UnitTests.xml` and `Build/FunctionalTests.xml` (not in `Tests/`)
+- Functional tests need a database; CI runs them against SQLite (`functional-test-db: 'sqlite'` in `.github/workflows/ci.yml`)
+<!-- AGENTS-GENERATED:END setup -->
+
+<!-- AGENTS-GENERATED:START filemap -->
+## Key Files
+| File | Purpose |
+|------|---------|
+| `Unit/Controller/UniversalMessengerControllerTest.php` | Controller unit tests (via `TestableUniversalMessengerController` subclass) |
+| `Unit/WebserviceConfigurationTest.php` | Extension configuration parsing tests |
+| `Unit/ViewHelpers/Format/PlaceholderViewHelperTest.php` | ViewHelper unit test |
+| `Functional/Controller/UniversalMessengerControllerArgumentsTest.php` | Functional controller test |
+| `Functional/Configuration/PagesTcaTest.php` | TCA integrity test for the `pages` overrides |
+| `Architecture/ArchitectureTest.php` | PHPat layer rules — runs inside PHPStan, **not** via PHPUnit |
+<!-- AGENTS-GENERATED:END filemap -->
+
+<!-- AGENTS-GENERATED:START structure -->
+## Test Structure
+```
+Tests/
+├── Unit/            # Fast, isolated unit tests (Build/UnitTests.xml)
+├── Functional/      # Tests with TYPO3/DB context (Build/FunctionalTests.xml)
+└── Architecture/    # PHPat rules, executed by composer ci:test:php:phpstan
+```
+<!-- AGENTS-GENERATED:END structure -->
+
+<!-- AGENTS-GENERATED:START commands -->
+## Running Tests
+| Type | Command |
+|------|---------|
+| Unit tests | `composer ci:test:php:unit` |
+| Functional tests | `composer ci:test:php:functional` |
+| Architecture rules | `composer ci:test:php:phpstan` (PHPat runs inside PHPStan) |
+| Single file | `.build/bin/phpunit --configuration Build/UnitTests.xml Tests/Unit/Path/To/Test.php` |
+<!-- AGENTS-GENERATED:END commands -->
+
+<!-- AGENTS-GENERATED:START patterns -->
+## Key Patterns (TYPO3-specific)
+- Unit tests extend `\TYPO3\TestingFramework\Core\Unit\UnitTestCase`
+- Functional tests extend `\TYPO3\TestingFramework\Core\Functional\FunctionalTestCase` and declare `$testExtensionsToLoad`
+- Protected controller internals are tested through a dedicated testable subclass (`Unit/Controller/TestableUniversalMessengerController.php`) — follow that pattern instead of reflection
+- New architecture constraints go into `Architecture/ArchitectureTest.php` as PHPat rules with a `because(...)` explanation
+<!-- AGENTS-GENERATED:END patterns -->
+
+<!-- AGENTS-GENERATED:START code-style -->
+## Code Style
+- Test class name matches source: `MyClass` → `MyClassTest`; same PSR-12/CGL rules as `Classes/`
+- Tests are analyzed by PHPStan too (`Build/phpstan.neon` includes `Tests/`) — keep them level-8 clean
+- Use data providers for multiple similar cases
+- Mock external services — never call the real Universal Messenger API in tests
+<!-- AGENTS-GENERATED:END code-style -->
+
+<!-- AGENTS-GENERATED:START security -->
+## Security
+- No real API credentials in tests or fixtures — use obviously fake values
+- Never weaken or skip a failing test to get CI green; fix the root cause
+- Expected exceptions/errors must be asserted, not left as noise in the test output
+<!-- AGENTS-GENERATED:END security -->
+
+<!-- AGENTS-GENERATED:START checklist -->
+## PR Checklist
+- [ ] `composer ci:test:php:unit` and `composer ci:test:php:functional` pass
+- [ ] New functionality has tests; regression tests were seen failing on the unfixed code
+- [ ] No hardcoded credentials or environment-specific paths
+- [ ] PHPStan still clean including the new test files: `composer ci:test:php:phpstan`
+<!-- AGENTS-GENERATED:END checklist -->
+
+<!-- AGENTS-GENERATED:START examples -->
+## Patterns to Follow
+> **Prefer looking at real code in this repo over generic examples.**
+> `Unit/Controller/UniversalMessengerControllerTest.php` (unit + testable subclass), `Functional/Configuration/PagesTcaTest.php` (functional TCA check), `Architecture/ArchitectureTest.php` (PHPat rule shape).
+<!-- AGENTS-GENERATED:END examples -->
+
+<!-- AGENTS-GENERATED:START help -->
+## When stuck
+- TYPO3 testing framework: https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/Testing/Index.html
+- PHPat rule reference: https://github.com/carlosas/phpat
+- Check `../docs/ARCHITECTURE.md` for the layer rules the architecture tests enforce
+- Review root AGENTS.md for project-wide conventions
+<!-- AGENTS-GENERATED:END help -->
+
+<!-- AGENTS-GENERATED:START skill-reference -->
+## Skill Reference
+> For comprehensive TYPO3 testing guidance including fixtures, mocking and CI setup:
+> **Invoke skill:** `typo3-testing`
+<!-- AGENTS-GENERATED:END skill-reference -->

--- a/Tests/CLAUDE.md
+++ b/Tests/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,43 @@
+# Architecture
+
+Agent-facing component map of the `universal_messenger` TYPO3 extension. Every path below exists in this repo; the dependency rules mirror `Tests/Architecture/ArchitectureTest.php` (PHPat, executed inside the PHPStan run — `composer ci:test:php:phpstan`).
+
+## System overview
+
+The extension adds a TYPO3 v14 backend module for sending newsletters through the Universal Messenger (UM) API. Newsletter channels are imported from the UM API into a local table via a CLI command; the backend module renders a newsletter page to standalone HTML (frontend request, post-processed by two PSR-15 middlewares) and hands it to the UM API for test or live dispatch. All API traffic goes through `netresearch/sdk-api-universal-messenger`.
+
+## Components
+
+| Component | Path | Role |
+|-----------|------|------|
+| Backend module controller | `Classes/Controller/UniversalMessengerController.php` (+ `AbstractBaseController.php`) | Channel selection, preview, test/live send |
+| Preview plugin controller | `Classes/Controller/NewsletterPreviewController.php` | Extbase frontend plugin rendering the preview (`preview` action) |
+| API service | `Classes/Service/UniversalMessengerService.php` | Singleton wrapper constructing the SDK client from `Classes/WebserviceConfiguration.php` |
+| Render service | `Classes/Service/NewsletterRenderService.php` | Renders newsletter pages to HTML via `RequestFactory` HTTP calls |
+| Infrastructure repositories | `Classes/Repository/` (`AbstractRepository`, `NewsletterRepository`, `EventFileRepository`) | UM-API-backed data access; depend on `UniversalMessengerService->api()` |
+| Domain layer | `Classes/Domain/Model/NewsletterChannel.php`, `Classes/Domain/Repository/NewsletterChannelRepository.php` | Extbase model/repository for the local channel table (`ext_tables.sql`, TCA in `Configuration/TCA/`) |
+| CLI command | `Classes/Command/ImportCommand.php` | `universal-messenger:newsletter-channels:import` (schedulable), syncs channels API → DB |
+| Frontend middlewares | `Classes/Middleware/InlineCssMiddleware.php`, `Classes/Middleware/DecodeCurlyBracesMiddleware.php` | CSS inlining (Emogrifier) and curly-brace decoding of the rendered newsletter response; ordered in `Configuration/RequestMiddlewares.php` |
+| Backend event listeners | `Classes/Backend/EventListener/` | Page-layout content, content-preview rendering, blinded-configuration options (tags in `Configuration/Services.yaml`) |
+| Data processing | `Classes/DataProcessing/ControlStructureProcessor.php` | FlexForm-driven data processor for the control-structure content element |
+| ViewHelpers | `Classes/ViewHelpers/` (`Condition/`, `Format/`, `Html/`) | Newsletter/mail-safe Fluid helpers (row/column/container/spacer/body) |
+| Configuration access | `Classes/Configuration.php`, `Classes/WebserviceConfiguration.php`, `Classes/Constants.php` | Typed access to extension settings (`ext_conf_template.txt`) |
+
+## Dependency rules (enforced by PHPat)
+
+From `Tests/Architecture/ArchitectureTest.php` — violations fail `composer ci:test:php:phpstan`:
+
+1. `ViewHelpers`, `Service`, `Backend\EventListener`, `Middleware`, `Command`, `Repository`, `DataProcessing` must **not** depend on `Controller` (controllers are the outermost layer).
+2. `Service` must **not** depend on `Repository` — the infrastructure repository layer depends on services, and the direction must stay acyclic.
+3. `Domain` is the innermost layer: it must **not** depend on `Controller`, `Service`, `Middleware`, `Command`, `Backend`, `ViewHelpers`, `Repository` or `DataProcessing`.
+
+## Data flow
+
+- **Channel import**: `ImportCommand` → `NewsletterRepository` (UM API via `UniversalMessengerService->api()`) → `NewsletterChannelRepository` persists `NewsletterChannel` rows.
+- **Newsletter send**: backend module (`UniversalMessengerController`) → `NewsletterRenderService` performs a frontend HTTP request → the response is post-processed by `InlineCssMiddleware`, then `DecodeCurlyBracesMiddleware` re-decodes the braces the CSS-inlining DOM step encoded → controller submits the final HTML through `NewsletterRepository` to the UM API.
+- **Preview**: same render path, exposed as the `NewsletterPreview` Extbase plugin (`ext_localconf.php`); preview parameters are excluded from cHash.
+
+## Key decisions
+
+- No ADR directory exists; design rationale lives in code comments (`ext_localconf.php` on TypoScript/site-set loading and the v14.2 page-type behavior, `checks.yml` on the CI gate pattern) and in `README.md`.
+- Version/compatibility facts: `ext_emconf.php` and `composer.json` are the source of truth (PHP ^8.2, TYPO3 ^14.0).

--- a/docs/exec-plans/README.md
+++ b/docs/exec-plans/README.md
@@ -1,0 +1,8 @@
+# Execution plans
+
+Working directory for agent execution plans, as required by the agent-harness docs/ structure.
+
+- `active/` — plans for work currently in progress (create the directory with the first plan)
+- `completed/` — finished plans kept for traceability
+
+A plan is a short markdown file: goal, ordered steps with verification commands, and completion criteria. Delete or move a plan to `completed/` when the work merges; do not let stale plans accumulate in `active/`.


### PR DESCRIPTION
Closes #112

## Explain the details

This repo had no agent documentation at all (harness Level 1 NONE). The AGENTS.md set was bootstrapped with `generate-agents.sh --style=thin` and then every generated claim was verified against the repo and corrected: the generated command table pointed at `vendor/bin/*` binaries that do not exist here (composer `bin-dir` is `.build/bin/`) and omitted the real `ci:*` composer scripts; the file map labeled `Build/` as "PHP classes" and `Documentation/` as RST docs (it contains only README screenshots, no manual); the Classes scaffold claimed a `netresearch\universal_messenger\` namespace (actual: `Netresearch\UniversalMessenger\`), PHPStan level 10 (actual: level 8 + strict rules + PHPat), ddev workflows and `Build/Scripts/runTests.sh` invocations that do not exist, and phantom scripts like `composer ci` / `ci:tests:unit`. All of that was replaced with verified content; empty generated sections (ci-rules, module-boundaries) were removed.

Root AGENTS.md (133 lines, index format) documents commands, file map, golden samples, verified repository settings (merge-commits-only, required check contexts read back from the rulesets API) and boundaries. Scoped AGENTS.md files for `Classes/` (component roles, DI conventions, layer rules), `Tests/` (unit/functional/PHPat split, single-file invocation), `Resources/` (XLIFF pairing, mail-safe templates, middleware interplay) and `.github/workflows/` (thin-caller pattern, gate.needs rule, intentional-drift marker). CLAUDE.md symlink next to every AGENTS.md; this repo has no `Documentation/` RST tree, so the symlink-vs-regular-file exception does not apply.

Agent-harness Level 2 infrastructure: `docs/ARCHITECTURE.md` renders the component map and the nine PHPat layer rules from `Tests/Architecture/ArchitectureTest.php` 1:1 (including the data flow through the two response-post-processing middlewares in their actual order), `docs/exec-plans/`, `Build/Scripts/verify-harness.sh`, and `.github/workflows/harness-verify.yml` as a thin caller of the shared `script-check` reusable so future drift fails CI.

## Test plan

- `validate-structure.sh`: 1 error (no root AGENTS.md) → **0 errors, 0 warnings**
- `verify-content.sh`: 1 error → **0 issues**
- `score-agents.sh`: 0 files, 0/100 → **average 98/100 over 5 files** (root 90, all scoped 100)
- `verify-harness.sh`: Level 1 NONE, 8 errors / 2 warnings → **Level 2 PARTIAL, 0 errors / 1 warning** (remaining warning: no git-hooks auto-setup — same accepted end state as t3x-nr-temporal-cache #80; adding hook infrastructure is out of scope for a docs PR, and the harness-verify CI gate treats warnings-only exit 2 as pass)
- All 5 make targets and all 10 documented composer scripts verified by the harness command check; markdown fences balanced in every added file; every referenced repo path checked for existence
