### PR TITLE
ci: adopt the shared runner stub and the reference config layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ logs/
 composer.lock
 
 # Build stuff
+.Build/
+# Old spelling. Without this line an existing .build/ stops being ignored the
+# moment bin-dir changes, and the next `git add -A` commits a vendor tree.
 .build/
 packages/
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@
 TYPO3 v14 backend extension (`universal_messenger`) for sending newsletters through the Universal Messenger API via `netresearch/sdk-api-universal-messenger`. Extension version: see `ext_emconf.php`.
 
 ## Commands
-> Source: composer.json scripts + Makefile (verified 2026-08-19). Run `composer install` first — binaries land in `.build/bin/` (composer `bin-dir`), vendors in `.build/vendor/`.
+> Source: composer.json scripts + Makefile (verified 2026-08-19). Run `composer install` first — binaries land in `.Build/bin/` (composer `bin-dir`), vendors in `.Build/vendor/`.
 
 <!-- AGENTS-GENERATED:START commands -->
 | Task | Command |
@@ -105,7 +105,7 @@ Architecture: component map and dependency rules in `docs/ARCHITECTURE.md` — t
 
 ### Never Do
 - Commit secrets, credentials, or sensitive data
-- Modify `.build/` or other generated files
+- Modify `.Build/` or other generated files
 - Push directly to `main` — open a PR
 - Merge a PR before all review threads are resolved
 - Squash commits during merge or rebase unless the user explicitly asked

--- a/Build/.phplint.yml
+++ b/Build/.phplint.yml
@@ -1,6 +1,6 @@
 path: ./
 jobs: 10
-cache: .build/.phplint.cache
+cache: .Build/.phplint.cache
 extensions:
     - php
 exclude:

--- a/Build/FunctionalTests.xml
+++ b/Build/FunctionalTests.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/13.2/phpunit.xsd"
-         bootstrap="../.build/vendor/typo3/testing-framework/Resources/Core/Build/FunctionalTestsBootstrap.php"
-         cacheDirectory="../.build/.phpunit.cache"
+         bootstrap="../.Build/vendor/typo3/testing-framework/Resources/Core/Build/FunctionalTestsBootstrap.php"
+         cacheDirectory="../.Build/.phpunit.cache"
          executionOrder="depends,defects"
          beStrictAboutOutputDuringTests="true"
          failOnRisky="true"
@@ -10,7 +10,7 @@
          colors="true"
 >
     <testsuites>
-        <testsuite name="universal_messenger_functional">
+        <testsuite name="functional">
             <directory>../Tests/Functional</directory>
         </testsuite>
     </testsuites>
@@ -19,7 +19,7 @@
         <env name="TYPO3_CONTEXT" value="Testing"/>
     </php>
     <logging>
-        <junit outputFile="../.build/phpunit-functional-report.xml"/>
+        <junit outputFile="../.Build/phpunit-functional-report.xml"/>
     </logging>
     <source restrictNotices="true"
             restrictWarnings="true"

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+#
+# Bootstrap for the shared TYPO3 extension test runner.
+#
+# Copy this file to Build/Scripts/runTests.sh in an extension. It is NOT the
+# runner: the runner is versioned once in netresearch/typo3-ci-workflows and
+# composer links it to .Build/bin/runTests.sh. This stub exists only because
+# the runner provisions the very environment it lives in, so it cannot be
+# behind a completed `composer install` — the first run on a fresh clone has
+# to create it.
+#
+# Per-extension settings belong in Build/Scripts/runTests.conf, never here.
+# Anything this stub grows beyond handing over is drift; fix the shared runner
+# instead.
+#
+
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# composer.json says where composer puts binaries. Hardcoding .Build/bin was
+# wrong for nine extensions in this fleet: seven use lowercase .build/bin and
+# two use vendor/bin, and there this stub would not have found the runner at
+# all. The runner detects the same thing for itself; the stub has to do it
+# before the runner exists.
+bin_dir() {
+    local dir=""
+    if type jq >/dev/null 2>&1; then
+        dir="$(jq -r '.config["bin-dir"] // ((.config["vendor-dir"] // "vendor") + "/bin") // empty' composer.json 2>/dev/null)"
+    else
+        dir="$(sed -n 's/.*"bin-dir"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' composer.json | head -n1)"
+        [[ -n "${dir}" ]] || dir="$(sed -n 's/.*"vendor-dir"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1\/bin/p' composer.json | head -n1)"
+    fi
+    printf '%s' "${dir:-vendor/bin}"
+}
+
+RUNNER="$(bin_dir)/runTests.sh"
+
+if [[ ! -x "${RUNNER}" ]]; then
+    echo "runTests.sh: ${RUNNER} not found — installing dependencies first." >&2
+    if ! type composer >/dev/null 2>&1; then
+        echo "runTests.sh: composer is not on PATH, cannot bootstrap ${RUNNER}." >&2
+        exit 1
+    fi
+    composer install --no-interaction --no-progress
+fi
+
+if [[ ! -x "${RUNNER}" ]]; then
+    echo "runTests.sh: ${RUNNER} is still missing after composer install." >&2
+    echo "             Is netresearch/typo3-ci-workflows in require-dev?" >&2
+    exit 1
+fi
+
+exec "${RUNNER}" "$@"

--- a/Build/phpstan.neon
+++ b/Build/phpstan.neon
@@ -1,10 +1,10 @@
 includes:
-    - %currentWorkingDirectory%/.build/vendor/phpstan/phpstan-strict-rules/rules.neon
-    - %currentWorkingDirectory%/.build/vendor/phpstan/phpstan-deprecation-rules/rules.neon
-    - %currentWorkingDirectory%/.build/vendor/phpstan/phpstan-phpunit/extension.neon
-    - %currentWorkingDirectory%/.build/vendor/phpstan/phpstan-phpunit/rules.neon
-    - %currentWorkingDirectory%/.build/vendor/saschaegerer/phpstan-typo3/extension.neon
-    - %currentWorkingDirectory%/.build/vendor/phpat/phpat/extension.neon
+    - %currentWorkingDirectory%/.Build/vendor/phpstan/phpstan-strict-rules/rules.neon
+    - %currentWorkingDirectory%/.Build/vendor/phpstan/phpstan-deprecation-rules/rules.neon
+    - %currentWorkingDirectory%/.Build/vendor/phpstan/phpstan-phpunit/extension.neon
+    - %currentWorkingDirectory%/.Build/vendor/phpstan/phpstan-phpunit/rules.neon
+    - %currentWorkingDirectory%/.Build/vendor/saschaegerer/phpstan-typo3/extension.neon
+    - %currentWorkingDirectory%/.Build/vendor/phpat/phpat/extension.neon
     - %currentWorkingDirectory%/Build/phpstan-baseline.neon
 
 parameters:
@@ -19,7 +19,7 @@ parameters:
         - %currentWorkingDirectory%/ext_localconf.php
 
     excludePaths:
-        - %currentWorkingDirectory%/.build/*
+        - %currentWorkingDirectory%/.Build/*
         - %currentWorkingDirectory%/ext_emconf.php
 
     ignoreErrors:

--- a/Build/phpunit.xml
+++ b/Build/phpunit.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/13.2/phpunit.xsd"
-         bootstrap="../.build/vendor/typo3/testing-framework/Resources/Core/Build/UnitTestsBootstrap.php"
-         cacheDirectory="../.build/.phpunit.cache"
+         bootstrap="../.Build/vendor/typo3/testing-framework/Resources/Core/Build/UnitTestsBootstrap.php"
+         cacheDirectory="../.Build/.phpunit.cache"
          executionOrder="depends,defects"
          beStrictAboutOutputDuringTests="true"
          failOnRisky="true"
@@ -11,7 +11,7 @@
          colors="true"
 >
     <testsuites>
-        <testsuite name="universal_messenger">
+        <testsuite name="unit">
             <directory>../Tests/Unit</directory>
         </testsuite>
     </testsuites>
@@ -20,7 +20,7 @@
         <env name="TYPO3_CONTEXT" value="Testing"/>
     </php>
     <logging>
-        <junit outputFile="../.build/phpunit-report.xml"/>
+        <junit outputFile="../.Build/phpunit-report.xml"/>
     </logging>
     <source restrictNotices="true"
             restrictWarnings="true"

--- a/Build/rector.php
+++ b/Build/rector.php
@@ -14,7 +14,7 @@ use Rector\DeadCode\Rector\ClassMethod\RemoveUselessUnionReturnDocblockRector;
 use Ssch\TYPO3Rector\Set\Typo3LevelSetList;
 use Ssch\TYPO3Rector\TYPO313\v0\MigrateAddUserTSConfigToUserTsConfigFileRector;
 
-$configure = require_once __DIR__ . '/../.build/vendor/netresearch/typo3-ci-workflows/config/rector/rector.php';
+$configure = require_once __DIR__ . '/../.Build/vendor/netresearch/typo3-ci-workflows/config/rector/rector.php';
 
 return static function (RectorConfig $rectorConfig) use ($configure): void {
     // Shared org base config: code-quality sets, rule skips, phpstan-rector.neon

--- a/Classes/AGENTS.md
+++ b/Classes/AGENTS.md
@@ -33,7 +33,7 @@ PHP code of the `universal_messenger` TYPO3 v14 extension: a backend module (Ext
 
 <!-- AGENTS-GENERATED:START setup -->
 ## Setup & environment
-- Install dev tools: `composer install` (binaries in `.build/bin/`, vendors in `.build/vendor/`)
+- Install dev tools: `composer install` (binaries in `.Build/bin/`, vendors in `.Build/vendor/`)
 - PHP: ^8.2 · TYPO3: ^14.0 (core, backend, frontend, extbase, fluid, lowlevel)
 - Services are autowired/autoconfigured via `Configuration/Services.yaml`; `Domain/Model/*` is excluded from DI
 <!-- AGENTS-GENERATED:END setup -->
@@ -115,7 +115,7 @@ Layer rules (enforced by PHPat, see `../docs/ARCHITECTURE.md`): nothing depends 
 ## When stuck
 - TYPO3 Core API: https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/
 - TCA Reference: https://docs.typo3.org/m/typo3/reference-tca/main/en-us/
-- SDK source: `.build/vendor/netresearch/sdk-api-universal-messenger/` (after `composer install`)
+- SDK source: `.Build/vendor/netresearch/sdk-api-universal-messenger/` (after `composer install`)
 - Check `../docs/ARCHITECTURE.md` for the component map and layer rules
 - Review root AGENTS.md for project-wide conventions
 <!-- AGENTS-GENERATED:END help -->

--- a/Tests/AGENTS.md
+++ b/Tests/AGENTS.md
@@ -9,8 +9,8 @@ Test suites of the `universal_messenger` extension: PHPUnit unit and functional 
 
 <!-- AGENTS-GENERATED:START setup -->
 ## Setup
-- `composer install` first — PHPUnit and the TYPO3 testing framework land in `.build/` (composer `vendor-dir`/`bin-dir`)
-- PHPUnit configs live in `Build/UnitTests.xml` and `Build/FunctionalTests.xml` (not in `Tests/`)
+- `composer install` first — PHPUnit and the TYPO3 testing framework land in `.Build/` (composer `vendor-dir`/`bin-dir`)
+- PHPUnit configs live in `Build/phpunit.xml` and `Build/FunctionalTests.xml` (not in `Tests/`)
 - Functional tests need a database; CI runs them against SQLite (`functional-test-db: 'sqlite'` in `.github/workflows/ci.yml`)
 <!-- AGENTS-GENERATED:END setup -->
 
@@ -30,7 +30,7 @@ Test suites of the `universal_messenger` extension: PHPUnit unit and functional 
 ## Test Structure
 ```
 Tests/
-├── Unit/            # Fast, isolated unit tests (Build/UnitTests.xml)
+├── Unit/            # Fast, isolated unit tests (Build/phpunit.xml)
 ├── Functional/      # Tests with TYPO3/DB context (Build/FunctionalTests.xml)
 └── Architecture/    # PHPat rules, executed by composer ci:test:php:phpstan
 ```
@@ -43,7 +43,7 @@ Tests/
 | Unit tests | `composer ci:test:php:unit` |
 | Functional tests | `composer ci:test:php:functional` |
 | Architecture rules | `composer ci:test:php:phpstan` (PHPat runs inside PHPStan) |
-| Single file | `.build/bin/phpunit --configuration Build/UnitTests.xml Tests/Unit/Path/To/Test.php` |
+| Single file | `.Build/bin/phpunit --configuration Build/phpunit.xml Tests/Unit/Path/To/Test.php` |
 <!-- AGENTS-GENERATED:END commands -->
 
 <!-- AGENTS-GENERATED:START patterns -->

--- a/composer.json
+++ b/composer.json
@@ -32,8 +32,8 @@
         "typo3/cms-scheduler": "Allows you to run CLI scripts as a task within TYPO3"
     },
     "config": {
-        "bin-dir": ".build/bin",
-        "vendor-dir": ".build/vendor",
+        "bin-dir": ".Build/bin",
+        "vendor-dir": ".Build/vendor",
         "discard-changes": true,
         "sort-packages": true,
         "optimize-autoloader": true,
@@ -57,7 +57,7 @@
     "extra": {
         "typo3/cms": {
             "extension-key": "universal_messenger",
-            "web-dir": ".build/public"
+            "web-dir": ".Build/public"
         },
         "branch-alias": {
             "dev-main": "3.0.x-dev"
@@ -75,7 +75,7 @@
     },
     "scripts": {
         "ci:cgl": [
-            "php-cs-fixer fix --config Build/.php-cs-fixer.dist.php --diff --verbose --cache-file .build/.php-cs-fixer.cache"
+            "php-cs-fixer fix --config Build/.php-cs-fixer.dist.php --diff --verbose --cache-file .Build/.php-cs-fixer.cache"
         ],
         "ci:rector": [
             "rector process --config Build/rector.php"
@@ -90,7 +90,7 @@
             "phplint --configuration Build/.phplint.yml"
         ],
         "ci:test:php:unit": [
-            "phpunit --configuration Build/UnitTests.xml"
+            "phpunit --configuration Build/phpunit.xml"
         ],
         "ci:test:php:functional": [
             "phpunit --configuration Build/FunctionalTests.xml"


### PR DESCRIPTION
Third repository onto the reference layout of [typo3-ci-workflows#186](https://github.com/netresearch/typo3-ci-workflows/issues/186), after [t3x-nr-repurpose#98](https://github.com/netresearch/t3x-nr-repurpose/pull/98) and [t3x-scheduler#53](https://github.com/netresearch/t3x-scheduler/pull/53). This repository matches `t3x-scheduler` exactly in shape, so the change is the same three moves.

**The runner stub**, 55 lines, taken unmodified from the package. `netresearch/typo3-ci-workflows` has been a dev dependency here all along (`^1.4`) and ships the runner as a composer `bin` — `.Build/bin/runTests.sh` existed with nothing pointing at it. No conf file: the runner finds `Build/phpunit.xml`, `Build/FunctionalTests.xml`, `Build/phpstan.neon` and `Build/rector.php` by itself.

**`Build/UnitTests.xml` → `Build/phpunit.xml`**, same directory, so the relative paths inside it are unchanged. The suites lose the extension-key prefix: `universal_messenger` → `unit`, `universal_messenger_functional` → `functional`. Nothing selected a suite by name — both composer scripts pass `--configuration` — so the rename only had to reach the two configs and the places that document them.

**`.build` → `.Build`** in the ten files that name it: both phpunit bootstraps, their cache directories and junit outputs, the phplint cache, seven paths in `phpstan.neon`, the rector include, and three documentation files. `.gitignore` keeps the old entry as well — without it an existing `.build/` stops being ignored the moment `bin-dir` changes, and the next `git add -A` commits a vendor tree. The stub is excluded from the replacement and verified byte-identical to the package afterwards: its comment about lowercase `.build/bin` describes the fleet, not this repository.

## Verified

Fresh install into `.Build`, PHP 8.4, sqlite:

| command | result |
|---|---|
| `runTests.sh -s unit` | OK (9 tests, 17 assertions) |
| `runTests.sh -s functional` | OK (3 tests, 4 assertions) |
| `CI=true composer ci:test:php:unit` | OK (9 tests, 17 assertions) |
| `typo3DatabaseDriver=pdo_sqlite CI=true composer ci:test:php:functional` | OK (3 tests, 4 assertions) |

Both paths are checked because they are different code: the runner starts a container, the composer script in CI runs phpunit directly, and the CI job takes the second. The variable in the last row is what the shared workflow's sqlite job exports.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01GSptxPLHWsttu9FuqVkvYZ)_
